### PR TITLE
Make site mobile-friendly

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -982,6 +982,14 @@ section:nth-of-type(even) {
 
 /* ───────────────────────────────────────────── responsive */
 @media (max-width: 900px) {
+  .shell,
+  .nav__inner {
+    padding-left: 36px;
+    padding-right: 36px;
+  }
+  .section {
+    padding: 64px 0;
+  }
   .hero {
     grid-template-columns: 1fr;
     min-height: auto;
@@ -1014,6 +1022,24 @@ section:nth-of-type(even) {
   }
 }
 
+@media (max-width: 768px) {
+  .shell,
+  .nav__inner {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+  .section {
+    padding: 56px 0;
+  }
+  .hero {
+    padding: 36px 0 28px;
+    gap: 28px;
+  }
+  .contact-grid {
+    gap: 24px;
+  }
+}
+
 @media (max-width: 600px) {
   .shell,
   .nav__inner {
@@ -1027,7 +1053,10 @@ section:nth-of-type(even) {
     columns: 1;
   }
   .section {
-    padding: 52px 0;
+    padding: 48px 0;
+  }
+  .hero {
+    padding: 28px 0 20px;
   }
   .hero__name {
     font-size: clamp(2.5rem, 12vw, 3.25rem);
@@ -1035,6 +1064,42 @@ section:nth-of-type(even) {
   .card__title,
   .entry__title {
     font-size: var(--font-size-lg);
+  }
+  .nav__links a {
+    padding: 5px 9px;
+    letter-spacing: 0.1em;
+  }
+  .footer {
+    margin-top: 56px;
+    margin-bottom: 36px;
+  }
+}
+
+@media (max-width: 480px) {
+  .shell,
+  .nav__inner {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  .nav__name {
+    font-size: var(--font-size-base);
+  }
+  .nav__links {
+    gap: 6px;
+  }
+  .nav__links a {
+    padding: 4px 8px;
+  }
+  .section {
+    padding: 36px 0;
+  }
+  .hero {
+    padding: 20px 0 16px;
+    gap: 20px;
+  }
+  .contact__row {
+    grid-template-columns: 1fr;
+    gap: 4px;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Chakra_Petch, Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -18,6 +18,11 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   weight: ["400", "500", "700"],
 });
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
 
 export const metadata: Metadata = {
   title: "Tyler Malone | Software Engineer & AI Engineer",


### PR DESCRIPTION
## Summary

- **Add missing viewport meta tag** via Next.js `Viewport` export — without this, mobile browsers render the full desktop layout and ignore all responsive breakpoints
- **Expand from 2 breakpoints to 4** (900px → 768px → 600px → 480px) for smoother layout transitions across phones and tablets
- **Gradually reduce horizontal padding** on shell/nav at each breakpoint (48 → 36 → 24 → 20 → 16px)
- **Progressively reduce section vertical padding** (76 → 64 → 56 → 48 → 36px) so content doesn't feel cramped on small screens
- **Tighten nav links** at 600px/480px (smaller padding, reduced letter-spacing) so they fit without awkward wrapping
- **Stack contact rows** to a single column at ≤480px so the label + value don't compete for space on very small phones
- **Reduce hero padding and gap** at each breakpoint in line with the rest of the spacing system

## Test plan

- [ ] Open site on a 375px-wide phone — verify content is readable with proper margins, no horizontal scroll
- [ ] Check nav at 480px — links should fit without overflowing or ugly wrapping
- [ ] Check contact section at 480px — label stacks above value cleanly
- [ ] Verify viewport meta is present in page source (`width=device-width, initial-scale=1`)
- [ ] Check 768px (tablet portrait) — layout should feel less cramped than before
- [ ] Confirm existing 900px responsive changes (stacked hero, 1-col cards, stacked timeline) are unaffected

https://claude.ai/code/session_01Udkb8VkbBg6tnS6kudK921

---
_Generated by [Claude Code](https://claude.ai/code/session_01Udkb8VkbBg6tnS6kudK921)_