### PR TITLE
Flatten floating cards, add scroll reveal, shrink mobile type

### DIFF
--- a/app/components/ScrollReveal.tsx
+++ b/app/components/ScrollReveal.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * Reveals elements tagged with `data-reveal` as they scroll into view.
+ * Re-scans on route change. Respects prefers-reduced-motion (shows everything
+ * immediately) and degrades gracefully without JS (CSS only hides content once
+ * this component flags the document via the `reveal-ready` class on <html>).
+ */
+export default function ScrollReveal() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.add('reveal-ready');
+
+    const els = Array.from(document.querySelectorAll<HTMLElement>('[data-reveal]'));
+    if (els.length === 0) return;
+
+    const reduceMotion =
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+
+    if (reduceMotion || !('IntersectionObserver' in window)) {
+      els.forEach((el) => el.classList.add('is-visible'));
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' }
+    );
+
+    els.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [pathname]);
+
+  return null;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -398,12 +398,12 @@ section:nth-of-type(even) {
   background: var(--surface);
   border: 1px solid var(--border-strong);
   border-left: 3px solid var(--border-strong);
-  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .timeline__row:hover {
   border-color: var(--accent);
-  box-shadow: 5px 5px 0 0 var(--accent);
+  background: var(--surface-2);
 }
 
 .timeline__row--active {
@@ -466,12 +466,12 @@ section:nth-of-type(even) {
   border: 1px solid var(--border-strong);
   border-top: 3px solid var(--accent);
   padding: var(--space-inner);
-  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .card:hover {
   border-color: var(--accent);
-  box-shadow: 6px 6px 0 0 var(--accent);
+  background: var(--surface-2);
 }
 
 .card__date {
@@ -541,12 +541,12 @@ section:nth-of-type(even) {
   border: 1px solid var(--border-strong);
   border-left: 3px solid var(--accent);
   padding: 22px;
-  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .skill-block:hover {
   border-color: var(--accent);
-  box-shadow: 4px 4px 0 0 var(--accent);
+  background: var(--surface-2);
 }
 
 .skill-block__head {
@@ -672,12 +672,12 @@ section:nth-of-type(even) {
   border: 1px solid var(--border-strong);
   border-left: 3px solid var(--border-strong);
   margin-bottom: var(--space-gap);
-  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .entry:hover {
   border-color: var(--accent);
-  box-shadow: 5px 5px 0 0 var(--accent);
+  background: var(--surface-2);
 }
 
 .entry:last-child {
@@ -833,6 +833,19 @@ section:nth-of-type(even) {
 }
 
 @media (max-width: 600px) {
+  /* dial the whole type scale down a notch so nothing feels oversized on phones */
+  :root {
+    --font-size-base: 0.9375rem;
+    --font-size-md: 1rem;
+    --font-size-lg: 1.2rem;
+    --font-size-xl: 1.4rem;
+    --font-size-2xl: 1.75rem;
+    --font-size-3xl: 2.25rem;
+    --font-size-4xl: 2.75rem;
+  }
+  body {
+    line-height: 1.6;
+  }
   .shell,
   .nav__inner {
     padding-left: 20px;
@@ -848,12 +861,30 @@ section:nth-of-type(even) {
     padding: 48px 0;
   }
   .hero__name {
-    font-size: clamp(2.5rem, 12vw, 3.25rem);
+    font-size: clamp(2.25rem, 11vw, 2.875rem);
+  }
+  .hero__role {
+    font-size: var(--font-size-base);
   }
   .card__title,
   .entry__title {
     font-size: var(--font-size-lg);
   }
+}
+
+/* ───────────────────────────────────────────── scroll reveal */
+/* Only hide content once JS has flagged the document (html.reveal-ready),
+   so the page degrades gracefully with JS disabled. */
+html.reveal-ready [data-reveal] {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+  will-change: opacity, transform;
+}
+
+html.reveal-ready [data-reveal].is-visible {
+  opacity: 1;
+  transform: none;
 }
 
 /* ───────────────────────────────────────────── motion preferences */
@@ -863,5 +894,11 @@ section:nth-of-type(even) {
   }
   .cursor {
     animation: none;
+  }
+  /* never hide content for users who prefer reduced motion */
+  html.reveal-ready [data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: none;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
+import ScrollReveal from "./components/ScrollReveal";
 
 const spaceGrotesk = Space_Grotesk({
   variable: "--font-display",
@@ -31,10 +32,20 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {/* Flag the document before paint so reveal styles apply without a flash,
+            and only when JS is enabled (graceful no-JS fallback). */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: "document.documentElement.classList.add('reveal-ready')",
+          }}
+        />
+      </head>
       <body
         className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} antialiased`}
       >
         {children}
+        <ScrollReveal />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
 
         {/* ── About (violet) ─────────────────────────────────── */}
         <section className="section accent-violet" id="about">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ ABOUT ]</span>
             <span className="section-bar__line" />
           </div>
@@ -74,7 +74,7 @@ export default function Home() {
 
         {/* ── Experience (coral) ─────────────────────────────── */}
         <section className="section accent-coral" id="experience">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ EXPERIENCE ]</span>
             <span className="section-bar__line" />
             <Link href="/work" className="section-bar__action">
@@ -83,7 +83,7 @@ export default function Home() {
           </div>
 
           <div className="timeline">
-            <div className="timeline__row timeline__row--active">
+            <div className="timeline__row timeline__row--active" data-reveal>
               <div className="timeline__meta">
                 <p className="timeline__company">WarTable by Freestyle Consulting</p>
                 <p className="timeline__role">Software Engineer (Full-Stack &amp; DevOps) — Contract</p>
@@ -102,7 +102,7 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="timeline__row">
+            <div className="timeline__row" data-reveal>
               <div className="timeline__meta">
                 <p className="timeline__company">HYVV</p>
                 <p className="timeline__role">Software Engineer (Full-Stack &amp; DevOps) — Contract</p>
@@ -119,7 +119,7 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="timeline__row">
+            <div className="timeline__row" data-reveal>
               <div className="timeline__meta">
                 <p className="timeline__company">Project Sustain, CSU</p>
                 <p className="timeline__role">Software Engineer &amp; Research Assistant</p>
@@ -138,7 +138,7 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="timeline__row">
+            <div className="timeline__row" data-reveal>
               <div className="timeline__meta">
                 <p className="timeline__company">CSU Robotics Lab</p>
                 <p className="timeline__role">Robotics Research Volunteer</p>
@@ -156,7 +156,7 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="timeline__row">
+            <div className="timeline__row" data-reveal>
               <div className="timeline__meta">
                 <p className="timeline__company">Colorado State University</p>
                 <p className="timeline__role">Undergraduate Teaching Assistant</p>
@@ -172,7 +172,7 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="timeline__row">
+            <div className="timeline__row" data-reveal>
               <div className="timeline__meta">
                 <p className="timeline__company">US Marine Corps</p>
                 <p className="timeline__role">Refrigeration Tech · Utilities QC NCO</p>
@@ -195,13 +195,13 @@ export default function Home() {
 
         {/* ── Education (amber) ──────────────────────────────── */}
         <section className="section accent-amber" id="education">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ EDUCATION ]</span>
             <span className="section-bar__line" />
           </div>
 
           <div className="timeline">
-            <div className="timeline__row">
+            <div className="timeline__row" data-reveal>
               <div className="timeline__meta">
                 <p className="timeline__company">Colorado State University</p>
                 <p className="timeline__role">B.S. Computer Science</p>
@@ -222,13 +222,13 @@ export default function Home() {
 
         {/* ── Projects (emerald) ─────────────────────────────── */}
         <section className="section accent-green" id="projects">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ PROJECTS ]</span>
             <span className="section-bar__line" />
           </div>
 
           <div className="card-grid">
-            <article className="card">
+            <article className="card" data-reveal>
               <p className="card__date">Aug 2025 – Present</p>
               <h3 className="card__title">
                 <Link href="https://www.mealplangenerator.ai" target="_blank" rel="noopener noreferrer">
@@ -247,7 +247,7 @@ export default function Home() {
               </a>
             </article>
 
-            <article className="card">
+            <article className="card" data-reveal>
               <p className="card__date">Jul 2025 – Jun 2026</p>
               <h3 className="card__title">
                 <Link href="https://wartable.ai" target="_blank" rel="noopener noreferrer">
@@ -271,14 +271,14 @@ export default function Home() {
 
         {/* ── Skills (rotating accents) ──────────────────────── */}
         <section className="section accent-violet" id="skills">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ SKILLS ]</span>
             <span className="section-bar__line" />
           </div>
 
           <div className="skills-grid">
             {skills.map((block, i) => (
-              <div className={`skill-block ${skillAccents[i % skillAccents.length]}`} key={block.category}>
+              <div className={`skill-block ${skillAccents[i % skillAccents.length]}`} key={block.category} data-reveal>
                 <h3 className="skill-block__head">{block.category}</h3>
                 <ul className="skill-block__list">
                   {block.items.map((item) => (
@@ -292,7 +292,7 @@ export default function Home() {
 
         {/* ── Contact (per-link accents) ─────────────────────── */}
         <section className="section accent-coral" id="contact">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ CONTACT ]</span>
             <span className="section-bar__line" />
           </div>
@@ -302,7 +302,7 @@ export default function Home() {
               I&apos;m available for contract work and consulting opportunities — full-stack development, agentic AI, or
               DevOps. Always open to discussing new projects, interesting challenges, or permanent roles.
             </p>
-            <div className="contact">
+            <div className="contact" data-reveal>
               <div className="contact__row accent-coral">
                 <span className="contact__label">email</span>
                 <a href="mailto:tyler@contraptionsoft.com">tyler@contraptionsoft.com</a>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -16,19 +16,19 @@ export default function Work() {
       <Nav />
 
       <main className="shell">
-        <header className="page-head">
+        <header className="page-head" data-reveal>
           <h1>Work &amp; Service Record</h1>
           <p>The full history — engineering, teaching, and four years in the US Marine Corps.</p>
         </header>
 
         {/* ── Engineering (coral) ────────────────────────────── */}
         <section className="section accent-coral">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ ENGINEERING ]</span>
             <span className="section-bar__line" />
           </div>
 
-          <div className="entry">
+          <div className="entry" data-reveal>
             <div className="entry__meta">
               <div className="org">WarTable by Freestyle Consulting</div>
               <div>Jul 2025 – Jun 2026</div>
@@ -69,7 +69,7 @@ export default function Work() {
             </div>
           </div>
 
-          <div className="entry">
+          <div className="entry" data-reveal>
             <div className="entry__meta">
               <div className="org">HYVV</div>
               <div>Dec 2024 – Dec 2025</div>
@@ -91,7 +91,7 @@ export default function Work() {
             </div>
           </div>
 
-          <div className="entry">
+          <div className="entry" data-reveal>
             <div className="entry__meta">
               <div className="org">Project Sustain, Colorado State University</div>
               <div>Jan 2025 – Aug 2025</div>
@@ -127,7 +127,7 @@ export default function Work() {
             </div>
           </div>
 
-          <div className="entry">
+          <div className="entry" data-reveal>
             <div className="entry__meta">
               <div className="org">Colorado State University</div>
               <div>Aug 2023 – Dec 2025</div>
@@ -143,7 +143,7 @@ export default function Work() {
             </div>
           </div>
 
-          <div className="entry">
+          <div className="entry" data-reveal>
             <div className="entry__meta">
               <div className="org">CSU Robotics Lab</div>
               <div>Jan 2024 – Dec 2025</div>
@@ -180,12 +180,12 @@ export default function Work() {
 
         {/* ── Military service (coral) ───────────────────────── */}
         <section className="section accent-coral">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ US MARINE CORPS ]</span>
             <span className="section-bar__line" />
           </div>
 
-          <div className="entry">
+          <div className="entry" data-reveal>
             <div className="entry__meta">
               <div className="org">US Marine Corps</div>
               <div>Oct 2018 – Oct 2022</div>
@@ -248,7 +248,7 @@ export default function Work() {
 
         {/* ── Service record (amber) ─────────────────────────── */}
         <section className="section accent-amber">
-          <div className="section-bar">
+          <div className="section-bar" data-reveal>
             <span className="section-bar__label">[ SERVICE RECORD ]</span>
             <span className="section-bar__line" />
           </div>
@@ -256,7 +256,7 @@ export default function Work() {
           <div className="awards">
             <div className="awards__group">
               <h4 className="awards__heading">Technical Training</h4>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">Basic Refrigeration And Air Conditioning Technician&apos;s Course</p>
                 <Image
                   src="/Reefer.png"
@@ -265,7 +265,7 @@ export default function Work() {
                   height={600}
                 />
               </div>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">Advanced Engineer Equipment Electrical Systems Technician&apos;s Course</p>
                 <Image
                   src="/ACourse.png"
@@ -278,7 +278,7 @@ export default function Work() {
 
             <div className="awards__group">
               <h4 className="awards__heading">Military Awards</h4>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">National Defense Service Medal</p>
                 <p className="awards__desc">
                   Awarded for active federal service in the armed forces between June 27, 1950 – July 1954; Jan. 1, 1961 –
@@ -286,21 +286,21 @@ export default function Work() {
                 </p>
                 <Image src="/NN.png" alt="National Defense Service Medal" width={160} height={160} />
               </div>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">Marine Corps Good Conduct Medal</p>
                 <p className="awards__desc">
                   Awarded to Marines after three consecutive years of honorable and faithful service.
                 </p>
                 <Image src="/GC.png" alt="Marine Corps Good Conduct Medal" width={160} height={160} />
               </div>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">USMC Sea Service Deployment Ribbon (x3)</p>
                 <p className="awards__desc">
                   Awarded to Marines who complete a deployment at sea or with an overseas unit.
                 </p>
                 <Image src="/SD.png" alt="USMC Sea Service Deployment Ribbon" width={160} height={160} />
               </div>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">Global War on Terrorism Service Medal</p>
                 <p className="awards__desc">
                   Awarded to military personnel who have served in support of operations related to the Global War on
@@ -312,7 +312,7 @@ export default function Work() {
 
             <div className="awards__group">
               <h4 className="awards__heading">Special Military Recognitions</h4>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">Meritorious Promotion to Noncommissioned Officer</p>
                 <Image
                   src="/promotion.png"
@@ -321,7 +321,7 @@ export default function Work() {
                   height={600}
                 />
               </div>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">Soochow Creek Medal</p>
                 <p className="awards__desc">
                   Awarded by the 4th Marine Regiment Commanding Officer, Colonel Tracy, for exemplary performance of duties
@@ -329,7 +329,7 @@ export default function Work() {
                 </p>
                 <Image src="/SoochowAward.png" alt="Soochow Creek Medal" width={800} height={600} />
               </div>
-              <div className="awards__item">
+              <div className="awards__item" data-reveal>
                 <p className="awards__name">Meritorious Mast</p>
                 <p className="awards__desc">
                   Won 1st place in company shooting competition, after which I competed against the Japanese Self-Defense


### PR DESCRIPTION
Addresses three UI gripes.

## 1. No more "floating" cards
Every card-like block (project cards, experience/education timeline rows, skill blocks, work-page entries) used a hard offset drop-shadow on hover (`box-shadow: 5–6px 5–6px 0 0 accent`) that made them lift/float off the page. Replaced with a flat treatment: accent border + a subtle surface fill on hover. Same hover feedback, nothing floats.

## 2. Scroll-to-reveal
Added a small `ScrollReveal` client component that uses `IntersectionObserver` to fade + slide content blocks in as they scroll into view (tagged with `data-reveal`). 
- Degrades gracefully without JS — content is only hidden once JS flags the document (`html.reveal-ready`), set before paint to avoid any flash.
- Respects `prefers-reduced-motion` (shows everything immediately).
- Re-scans on client-side route changes.

## 3. Smaller text on mobile
Dialed the whole type scale down a notch at `≤600px` (via the CSS custom properties) and tightened the hero name/role so nothing feels oversized on phones.

## Verification
- `next build` ✓
- `eslint app` ✓ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)