### PR TITLE
Add Google Analytics (gtag.js)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-75RZYE6V5C"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-0GNGQLQQ8Q"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-75RZYE6V5C');
+  gtag('config', 'G-0GNGQLQQ8Q');
 </script>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-75RZYE6V5C"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-75RZYE6V5C');
+</script>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Tyler Malone — Software Engineer</title>


### PR DESCRIPTION
Adds the Google Analytics tag (gtag.js) for measurement ID `G-75RZYE6V5C`.

The snippet is placed immediately after the opening `<head>` element in `index.html`, as instructed by the Google Analytics setup flow. Since this is a single-page static site, this covers every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)