### PR TITLE
Add sitemap.xml and robots.txt for search engines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://tylermmprojects.com/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://tylermmprojects.com/sitemap.xml
+Sitemap: https://www.tylermmprojects.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://tylermmprojects.com/</loc>
+    <loc>https://www.tylermmprojects.com/</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tylermmprojects.com/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
Adds an XML sitemap so the site can be submitted to Google Search Console, plus a `robots.txt` that allows crawling and points to the sitemap.

It's a single-page site, but having a sitemap in place lets Search Console index it cleanly and gives a home for additional URLs later.

## Changes
- `sitemap.xml` — lists the homepage (`https://tylermmprojects.com/`) with `lastmod`, `changefreq`, and `priority`.
- `robots.txt` — `Allow: /` for all crawlers and a `Sitemap:` reference.

## Notes
After merge + deploy, submit `https://tylermmprojects.com/sitemap.xml` in Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)