### PR TITLE
Update domain to tmalone.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tylermmprojects.com
+# tmalone.dev
 
 Personal portfolio for **Tyler Malone** — Software Engineer (full-stack · DevOps · agentic AI).
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.tylermmprojects.com/sitemap.xml
+Sitemap: https://www.tmalone.dev/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.tylermmprojects.com/</loc>
-    <lastmod>2026-06-10</lastmod>
+    <loc>https://www.tmalone.dev/</loc>
+    <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Repo was renamed from `tylermmprojects.com` to `tmalone.dev` and the domain has changed. Google Analytics data stream and Search Console were updated separately.

## Changes
- `sitemap.xml` — canonical `<loc>` now `https://www.tmalone.dev/`; bumped `lastmod` to 2026-06-11
- `robots.txt` — `Sitemap:` URL updated to `https://www.tmalone.dev/sitemap.xml`
- `README.md` — title updated to `tmalone.dev`

No other references to the old domain remained (`index.html` has no canonical/og:url tags). Kept the `www.` canonical convention already in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)