### PR TITLE
Add custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-0GNGQLQQ8Q"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-0GNGQLQQ8Q');
+</script>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>404 — Lost in the void · Tyler Malone</title>
+<meta name="description" content="This page drifted off the map. Return to tmalone.dev." />
+<meta name="robots" content="noindex" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=Hanken+Grotesk:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/assets/css/styles.css" />
+</head>
+<body>
+
+<div class="grain" aria-hidden="true"></div>
+
+<!-- ============ NAV ============ -->
+<header class="nav is-stuck" id="top">
+  <a href="/" class="nav__brand">
+    <span class="nav__sigil" aria-hidden="true">✦</span>
+    <span class="nav__name">Tyler Malone</span>
+  </a>
+  <a href="/" class="nav__cta">Home</a>
+</header>
+
+<main>
+<section class="error" data-layer="Deep space">
+  <div class="error__media" aria-hidden="true">
+    <img src="/assets/img/carina.jpg" alt="" />
+    <div class="error__veil"></div>
+  </div>
+  <canvas id="starfield" class="hero__stars" aria-hidden="true"></canvas>
+
+  <div class="error__inner">
+    <p class="error__eyebrow">
+      <span class="coord">Signal lost</span>
+      <span class="error__eyebrow__sep">·</span>
+      <span>Off the map</span>
+    </p>
+    <p class="error__code">404</p>
+    <h1 class="error__title">This coordinate doesn't exist</h1>
+    <p class="error__lede">
+      You've drifted past the edge of the map — the page you're looking for isn't out here.
+      Let's get you back to solid ground.
+    </p>
+    <a href="/" class="error__home"><span class="arrow" aria-hidden="true">←</span> Return home</a>
+  </div>
+</section>
+</main>
+
+<footer class="foot">
+  <span class="foot__name">Tyler Malone</span>
+  <span class="foot__credit">Imagery: NASA · ESA · STScI · USGS/NPS · Wikimedia Commons — public domain &amp; CC0</span>
+  <a href="/" class="foot__top">Back home ↑</a>
+</footer>
+
+<script src="/assets/js/main.js"></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -622,6 +622,77 @@ main, .nav, .foot { position: relative; z-index: 2; }
 .foot__top:hover { color: var(--gold); }
 
 /* ============================================================
+   404 — lost in the void
+   ============================================================ */
+.error {
+  position: relative;
+  min-height: 100svh;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  text-align: center;
+  padding: 8rem var(--gut) 6rem;
+  overflow: hidden;
+}
+.error__media { position: absolute; inset: 0; z-index: -1; }
+.error__media img {
+  position: absolute; top: -8%; left: 0;
+  width: 100%; height: 116%;
+  object-fit: cover; object-position: center 40%;
+  opacity: 0.5;
+  filter: saturate(1.05) contrast(1.02);
+}
+.error__veil {
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(120% 90% at 50% 50%, transparent 0%, rgba(4,5,12,0.6) 68%, var(--void) 100%),
+    linear-gradient(180deg, rgba(4,5,12,0.6) 0%, transparent 30%, transparent 60%, var(--void) 100%);
+}
+.error__inner { max-width: 60ch; position: relative; z-index: 1; }
+.error__eyebrow {
+  display: inline-flex; align-items: center; gap: .85rem; flex-wrap: wrap;
+  justify-content: center;
+  font-family: var(--f-mono); font-size: .78rem; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--text-dim);
+  margin-bottom: 1.6rem;
+}
+.error__eyebrow .coord { color: var(--cyan); }
+.error__eyebrow__sep { color: var(--text-mute); }
+.error__code {
+  font-family: var(--f-display);
+  font-weight: 300; font-style: italic;
+  font-size: clamp(6rem, 26vw, 18rem);
+  line-height: 0.82;
+  letter-spacing: -0.02em;
+  background: linear-gradient(92deg, var(--gold) 0%, var(--rose) 55%, var(--cyan) 100%);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+  margin-bottom: 1rem;
+}
+.error__title {
+  font-family: var(--f-display); font-weight: 400;
+  font-size: clamp(1.8rem, 5vw, 3rem); line-height: 1.05;
+  color: var(--star); margin-bottom: 1.2rem;
+}
+.error__lede {
+  font-family: var(--f-display);
+  font-size: clamp(1.1rem, 2.2vw, 1.4rem);
+  font-weight: 300; line-height: 1.5;
+  color: var(--text-dim); margin: 0 auto 2.6rem; max-width: 42ch;
+}
+.error__home {
+  display: inline-flex; align-items: center; gap: .6rem;
+  font-family: var(--f-mono); font-size: .78rem; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--gold);
+  border: 1px solid rgba(233,201,135,0.35); border-radius: 100px;
+  padding: .75rem 1.4rem;
+  transition: background .3s, border-color .3s, color .3s, transform .3s var(--ease);
+}
+.error__home:hover {
+  background: var(--gold); color: #1a1205; border-color: var(--gold);
+  transform: translateY(-2px);
+}
+.error__home .arrow { transition: transform .4s var(--ease); }
+.error__home:hover .arrow { transform: translateX(-4px); }
+
+/* ============================================================
    REVEAL ANIMATIONS
    ============================================================ */
 .reveal { opacity: 0; transform: translateY(22px); filter: blur(7px); }


### PR DESCRIPTION
Adds a custom 404 page so any path that doesn't exist on the site lands on something on-brand instead of a bare/default error.

## How it works
On Vercel, a static deployment automatically serves `/404.html` from the output root for any unmatched route (with a proper `404` status). No `vercel.json` or routing config needed.

## What's here
- **`404.html`** — reuses the existing cosmic theme (starfield canvas, grain, nav, footer) with a "lost in the void" treatment: a gradient italic `404`, a short message, and a **Return home** button. Carries the GA tag so 404 hits are tracked, and is marked `noindex`.
- **`assets/css/styles.css`** — a small scoped `.error` style block; no existing styles changed.

## Notes
- Asset references use **root-absolute paths** (`/assets/...`) so CSS/JS/imagery resolve correctly even when the 404 is served at a deep path like `/foo/bar`.
- Verified locally that `404.html`, CSS, JS, and the background image all return `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)