### PR TITLE
Add flyable rocket mode + fix Back to top

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,6 +39,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; background: #000; }
+html.flying { scroll-behavior: auto; }
 
 body {
   font-family: var(--f-body);
@@ -123,6 +124,94 @@ main, .nav, .foot { position: relative; z-index: 2; }
   transition: background .3s, border-color .3s, color .3s;
 }
 .nav__cta:hover { background: var(--gold); color: #1a1205; border-color: var(--gold); }
+
+.nav__actions { display: flex; align-items: center; gap: .7rem; }
+
+/* fly toggle button */
+.nav__fly {
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--cyan);
+  background: transparent; cursor: pointer;
+  border: 1px solid rgba(127,214,232,0.35); border-radius: 50%;
+  width: 2.2rem; height: 2.2rem; padding: 0;
+  transition: background .3s, border-color .3s, color .3s, box-shadow .3s;
+}
+.nav__fly-ico { font-size: 1rem; line-height: 1; transition: transform .4s var(--ease); }
+.nav__fly:hover { background: rgba(127,214,232,0.1); border-color: var(--cyan); color: var(--star); }
+.nav__fly:hover .nav__fly-ico { transform: translateY(-2px) rotate(-12deg); }
+.nav__fly[aria-pressed="true"] {
+  background: var(--cyan); color: #062028; border-color: var(--cyan);
+  box-shadow: 0 0 18px rgba(127,214,232,0.5);
+}
+.nav__fly[aria-pressed="true"] .nav__fly-ico { transform: rotate(-35deg); }
+
+/* ============================================================
+   FLIGHT MODE — drive a rocket to scroll the page
+   ============================================================ */
+.rocket {
+  position: fixed; left: 0; top: 0;
+  width: 48px; height: 84px;
+  margin-left: -24px; margin-top: -42px;   /* center on the (px,py) origin */
+  z-index: 65; pointer-events: none;
+  transform: translate3d(-100px, -100px, 0);
+  will-change: transform;
+  filter: drop-shadow(0 4px 10px rgba(0,0,0,0.45)) drop-shadow(0 0 14px rgba(127,214,232,0.45));
+}
+.rocket[hidden] { display: none; }
+.rocket__svg { display: block; overflow: visible; }
+
+/* afterburner — Shift held */
+.rocket.is-boosting {
+  filter: drop-shadow(0 4px 12px rgba(0,0,0,0.5)) drop-shadow(0 0 22px rgba(127,214,232,0.85));
+}
+.rocket.is-boosting .rocket__flame {
+  background: linear-gradient(180deg, #ffffff 0%, #fff0c0 22%, var(--cyan) 55%, rgba(127,214,232,0) 100%);
+  filter: blur(0.4px) drop-shadow(0 0 14px rgba(127,214,232,0.9));
+}
+
+/* exhaust flame — height driven by --thrust (0..1) from JS */
+.rocket__flame {
+  --thrust: 0;
+  position: absolute; left: 50%; top: 76px;
+  width: calc(11px + 7px * var(--thrust));
+  height: calc(6px + 30px * var(--thrust));
+  transform: translateX(-50%);
+  border-radius: 50% 50% 50% 50% / 22% 22% 78% 78%;
+  background: linear-gradient(180deg, #fff6d8 0%, var(--gold) 26%, var(--rose) 62%, rgba(224,138,168,0) 100%);
+  opacity: calc(0.25 + 0.75 * var(--thrust));
+  filter: blur(0.4px) drop-shadow(0 0 8px rgba(233,201,135,0.7));
+  transform-origin: 50% 0%;
+  animation: flameFlicker .09s steps(2) infinite;
+}
+@keyframes flameFlicker {
+  0%   { transform: translateX(-50%) scaleY(1) scaleX(1); }
+  100% { transform: translateX(-52%) scaleY(0.86) scaleX(1.12); }
+}
+
+/* on-screen d-pad (touch) */
+.dpad {
+  position: fixed; right: 1.1rem; bottom: 1.4rem; z-index: 66;
+  display: none;
+  grid-template-columns: repeat(3, 48px); grid-template-rows: repeat(3, 48px);
+  gap: 6px; touch-action: none;
+}
+.dpad[hidden] { display: none !important; }
+.dpad__btn {
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1rem; color: var(--star); cursor: pointer;
+  background: rgba(7,10,22,0.7); backdrop-filter: blur(10px);
+  border: 1px solid var(--line); border-radius: 12px;
+  -webkit-user-select: none; user-select: none;
+}
+.dpad__btn:active { background: rgba(127,214,232,0.25); border-color: var(--cyan); }
+.dpad__up    { grid-column: 2; grid-row: 1; }
+.dpad__left  { grid-column: 1; grid-row: 2; }
+.dpad__right { grid-column: 3; grid-row: 2; }
+.dpad__down  { grid-column: 2; grid-row: 3; }
+@media (hover: none) and (pointer: coarse) {
+  .dpad.is-on { display: grid; }
+}
+
 @media (max-width: 880px) {
   .nav__links { display: none; }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -133,6 +133,17 @@
   onScroll();
   window.addEventListener("scroll", onScroll, { passive: true });
 
+  /* ---------------- "Back to top" / brand links ----------------
+     #top sits on the fixed <header>, which is always in view, so the
+     browser won't scroll to it. Scroll to the document top instead. */
+  document.querySelectorAll('a[href="#top"]').forEach((a) => {
+    a.addEventListener("click", (e) => {
+      e.preventDefault();
+      window.scrollTo({ top: 0, behavior: reduceMotion ? "auto" : "smooth" });
+      history.replaceState(null, "", location.pathname + location.search);
+    });
+  });
+
   /* ---------------- Parallax + cinematic zoom (scenic imagery) ---------------- */
   const parallaxEls = Array.from(document.querySelectorAll("[data-parallax]"));
   if (parallaxEls.length && !reduceMotion) {
@@ -162,4 +173,175 @@
     window.addEventListener("resize", update, { passive: true });
     update();
   }
+
+  /* ============================================================
+     Flight mode — drive a rocket with WASD / arrows; flying past
+     the top or bottom of the comfort band scrolls the page.
+     ============================================================ */
+  (function flight() {
+    const btn = document.getElementById("flyBtn");
+    const rocket = document.getElementById("rocket");
+    const flame = rocket && rocket.querySelector(".rocket__flame");
+    const dpad = document.getElementById("dpad");
+    if (!btn || !rocket || !flame) return;
+
+    const ACCEL = 2200;     // px/s^2 of thrust
+    const DAMP = 2.6;       // velocity damping per second
+    const MAXV = 1100;      // px/s speed cap
+    const MARGIN = 70;      // how close the rocket gets to viewport edges
+    const BOOST_ACCEL = 2;  // thrust multiplier while Shift is held
+    const BOOST_MAXV = 2100; // raised speed cap while boosting
+
+    let active = false;
+    let raf = 0, last = 0;
+    let px = 0, py = 0, vx = 0, vy = 0, rot = 0, thrust = 0;
+    const keys = { up: false, down: false, left: false, right: false, boost: false };
+
+    const KEYMAP = {
+      ArrowUp: "up", KeyW: "up",
+      ArrowDown: "down", KeyS: "down",
+      ArrowLeft: "left", KeyA: "left",
+      ArrowRight: "right", KeyD: "right",
+    };
+
+    function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+
+    function lerpAngle(a, b, t) {
+      let d = ((b - a + 540) % 360) - 180;
+      return a + d * t;
+    }
+
+    function render() {
+      rocket.style.transform = `translate3d(${px.toFixed(1)}px, ${py.toFixed(1)}px, 0) rotate(${rot.toFixed(2)}deg)`;
+      flame.style.setProperty("--thrust", thrust.toFixed(3));
+    }
+
+    function step(now) {
+      const dt = Math.min((now - last) / 1000, 0.05);
+      last = now;
+
+      const ax = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
+      const ay = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
+      const boosting = keys.boost && (ax !== 0 || ay !== 0);
+
+      const accel = ACCEL * (keys.boost ? BOOST_ACCEL : 1);
+      vx += ax * accel * dt;
+      vy += ay * accel * dt;
+
+      // exponential damping toward rest
+      const damp = Math.exp(-DAMP * dt);
+      vx *= damp; vy *= damp;
+
+      // speed cap (raised while boosting)
+      const maxv = keys.boost ? BOOST_MAXV : MAXV;
+      const sp = Math.hypot(vx, vy);
+      if (sp > maxv) { vx = vx / sp * maxv; vy = vy / sp * maxv; }
+      rocket.classList.toggle("is-boosting", boosting);
+
+      // horizontal: move within the viewport, soft-bounce off the sides
+      px += vx * dt;
+      const xMin = MARGIN, xMax = innerWidth - MARGIN;
+      if (px < xMin) { px = xMin; vx = Math.abs(vx) * 0.4; }
+      else if (px > xMax) { px = xMax; vx = -Math.abs(vx) * 0.4; }
+
+      // vertical: stay inside the band; overflow drives the page scroll.
+      py += vy * dt;
+      const yMin = MARGIN, yMax = innerHeight - MARGIN;
+      if (py > yMax) {
+        const over = py - yMax;
+        const before = window.scrollY;
+        window.scrollBy(0, over);
+        const moved = window.scrollY - before;
+        py = yMax + (over - moved);           // leftover (page bottom) pushes rocket to the edge
+        if (moved < over - 0.5) vy *= 0.6;
+      } else if (py < yMin) {
+        const over = yMin - py;
+        const before = window.scrollY;
+        window.scrollBy(0, -over);
+        const moved = before - window.scrollY;
+        py = yMin - (over - moved);
+        if (moved < over - 0.5) vy *= 0.6;
+      }
+      py = clamp(py, 6, innerHeight - 6);
+
+      // point the nose along the direction of travel (nose-up = 0deg);
+      // hold the last heading when nearly stopped to avoid jitter.
+      if (sp > 40) {
+        const targetRot = Math.atan2(vx, -vy) * 180 / Math.PI;
+        rot = lerpAngle(rot, targetRot, 0.2);
+      }
+      let wantThrust = clamp((Math.abs(ax) + Math.abs(ay)) * 0.7 + sp / MAXV * 0.6, 0, 1);
+      if (boosting) wantThrust = 1.4;          // afterburner flare
+      thrust += (wantThrust - thrust) * 0.25;
+
+      render();
+      raf = requestAnimationFrame(step);
+    }
+
+    function start() {
+      if (active) return;
+      active = true;
+      px = innerWidth / 2;
+      py = innerHeight - MARGIN;        // launch from near the bottom
+      vx = 0; vy = -MAXV * 0.5; rot = 0; thrust = 1;
+      rocket.hidden = false;
+      if (dpad) { dpad.hidden = false; dpad.classList.add("is-on"); }
+      document.documentElement.classList.add("flying");
+      btn.setAttribute("aria-pressed", "true");
+      render();
+      last = performance.now();
+      raf = requestAnimationFrame(step);
+    }
+
+    function stop() {
+      if (!active) return;
+      active = false;
+      cancelAnimationFrame(raf);
+      keys.up = keys.down = keys.left = keys.right = keys.boost = false;
+      rocket.classList.remove("is-boosting");
+      rocket.hidden = true;
+      if (dpad) { dpad.hidden = true; dpad.classList.remove("is-on"); }
+      document.documentElement.classList.remove("flying");
+      btn.setAttribute("aria-pressed", "false");
+    }
+
+    function toggle() { active ? stop() : start(); }
+
+    btn.addEventListener("click", toggle);
+
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && active) { stop(); return; }
+      if (!active) return;
+      if (e.key === "Shift") { keys.boost = true; return; }
+      const dir = KEYMAP[e.code];
+      if (!dir) return;
+      keys[dir] = true;
+      e.preventDefault();                // stop arrows/space from scrolling on their own
+    });
+    window.addEventListener("keyup", (e) => {
+      if (e.key === "Shift") keys.boost = false;
+      const dir = KEYMAP[e.code];
+      if (dir) keys[dir] = false;
+    });
+
+    // on-screen d-pad for touch
+    if (dpad) {
+      dpad.querySelectorAll(".dpad__btn").forEach((b) => {
+        const dir = b.getAttribute("data-dir");
+        const on = (e) => { e.preventDefault(); keys[dir] = true; };
+        const off = (e) => { e.preventDefault(); keys[dir] = false; };
+        b.addEventListener("pointerdown", on);
+        b.addEventListener("pointerup", off);
+        b.addEventListener("pointerleave", off);
+        b.addEventListener("pointercancel", off);
+      });
+    }
+
+    // if the window shrinks, keep the rocket on screen
+    window.addEventListener("resize", () => {
+      if (!active) return;
+      px = clamp(px, MARGIN, innerWidth - MARGIN);
+      py = clamp(py, MARGIN, innerHeight - MARGIN);
+    }, { passive: true });
+  })();
 })();

--- a/index.html
+++ b/index.html
@@ -39,8 +39,52 @@
     <a href="#service">Service</a>
     <a href="#contact">Contact</a>
   </nav>
-  <a href="#contact" class="nav__cta">Available</a>
+  <div class="nav__actions">
+    <button type="button" class="nav__fly" id="flyBtn" aria-pressed="false" aria-label="Fly a rocket" title="Fly a rocket — WASD or arrow keys">
+      <span class="nav__fly-ico" aria-hidden="true">🚀</span>
+    </button>
+    <a href="#contact" class="nav__cta">Available</a>
+  </div>
 </header>
+
+<!-- ============ FLIGHT MODE ============ -->
+<div class="rocket" id="rocket" aria-hidden="true" hidden>
+  <svg class="rocket__svg" viewBox="0 0 48 84" width="48" height="84" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="rkBody" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0" stop-color="#9aa0c8"/>
+        <stop offset="0.45" stop-color="#f4f1ff"/>
+        <stop offset="1" stop-color="#7e84ad"/>
+      </linearGradient>
+      <linearGradient id="rkNose" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0" stop-color="#d8b873"/>
+        <stop offset="0.5" stop-color="#e9c987"/>
+        <stop offset="1" stop-color="#b8965a"/>
+      </linearGradient>
+      <radialGradient id="rkWin" cx="0.4" cy="0.35" r="0.8">
+        <stop offset="0" stop-color="#d6f6ff"/>
+        <stop offset="0.55" stop-color="#7fd6e8"/>
+        <stop offset="1" stop-color="#1d5a6c"/>
+      </radialGradient>
+    </defs>
+    <path d="M14 52 L3 71 L15 64 Z" fill="#e08aa8"/>
+    <path d="M34 52 L45 71 L33 64 Z" fill="#e08aa8"/>
+    <path d="M24 2 C32 12 34 22 34 40 L34 58 C34 66 30 72 24 77 C18 72 14 66 14 58 L14 40 C14 22 16 12 24 2 Z" fill="url(#rkBody)" stroke="rgba(11,15,32,0.5)" stroke-width="1"/>
+    <path d="M24 2 C28 7 30 12 31 19 L17 19 C18 12 20 7 24 2 Z" fill="url(#rkNose)"/>
+    <circle cx="24" cy="35" r="7.5" fill="url(#rkWin)" stroke="rgba(11,15,32,0.55)" stroke-width="1.5"/>
+    <circle cx="21.5" cy="32.5" r="2" fill="rgba(255,255,255,0.7)"/>
+    <rect x="13.5" y="54" width="21" height="4" rx="2" fill="rgba(11,15,32,0.35)"/>
+  </svg>
+  <span class="rocket__flame" aria-hidden="true"></span>
+</div>
+
+
+<div class="dpad" id="dpad" hidden aria-hidden="true">
+  <button class="dpad__btn dpad__up"    data-dir="up">▲</button>
+  <button class="dpad__btn dpad__left"  data-dir="left">◀</button>
+  <button class="dpad__btn dpad__right" data-dir="right">▶</button>
+  <button class="dpad__btn dpad__down"  data-dir="down">▼</button>
+</div>
 
 <main>
 


### PR DESCRIPTION
## Summary

- Adds a 🚀 button to the nav that launches a drivable rocket pod over the page.
- **WASD / arrow keys** fly the rocket; it points the way it's moving and banks into turns. Flying past the top/bottom of the viewport scrolls the page, so you can pilot through the site instead of scrolling.
- **Shift** is an afterburner boost (higher accel + speed cap, bigger flame).
- **Esc** (or the button) lands the rocket. A touch d-pad appears on coarse-pointer devices.
- Smooth-scroll is disabled while flying so the per-frame `scrollBy` stays crisp.

## Unrelated fix

- **Back to top** (and the brand logo) didn't work: `#top` lives on the `position: fixed` nav header, which is always in view, so the browser never scrolled. Now scrolls to the document top in JS (respects `prefers-reduced-motion`).

## Testing

Drove the rocket and exercised the links via Chrome DevTools Protocol in headless Chrome:
- Flying down ~1.2s scrolled the page 0 → 480px; heading tracks travel direction.
- Boosted dive covered ~2.9× the distance of an unboosted one over the same time.
- "Back to top" from the page bottom (scrollY 3833) scrolled cleanly to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)