### PR TITLE
Turn rocket flight mode into Cosmic Skirmish game

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -212,6 +212,139 @@ main, .nav, .foot { position: relative; z-index: 2; }
   .dpad.is-on { display: grid; }
 }
 
+/* ============================================================
+   GAME — combat layer, HUD, achievements, game over
+   ============================================================ */
+.game-layer {
+  position: fixed; inset: 0; z-index: 64; pointer-events: none;
+}
+.game-layer[hidden] { display: none !important; }
+
+/* red vignette when the hull takes a hit */
+.hit-flash {
+  position: fixed; inset: 0; z-index: 118; pointer-events: none;
+  opacity: 0; transition: opacity .45s ease;
+  background: radial-gradient(circle at 50% 50%, rgba(224,40,80,0) 32%, rgba(224,40,80,0.55) 100%);
+}
+
+/* HUD — hull bar + run stats */
+.hud {
+  position: fixed; top: 4.4rem; left: 50%; transform: translateX(-50%);
+  z-index: 70; pointer-events: none;
+}
+.hud[hidden] { display: none !important; }
+.hud__bar {
+  display: flex; flex-direction: column; align-items: center; gap: .5rem;
+  padding: .6rem .9rem;
+  background: rgba(7,10,22,0.6); backdrop-filter: blur(10px);
+  border: 1px solid var(--line); border-radius: 14px;
+  box-shadow: 0 6px 26px rgba(0,0,0,0.4);
+}
+.hud__health {
+  width: min(46vw, 260px); height: 10px; border-radius: 6px; overflow: hidden;
+  background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.08);
+}
+.hud__health-fill {
+  display: block; height: 100%; width: 100%; border-radius: 6px;
+  transition: width .12s linear, background .3s;
+  background: linear-gradient(90deg, #7fd6e8, #9af0c0);
+  box-shadow: 0 0 12px rgba(127,214,232,0.6);
+}
+.hud__health-fill[data-lvl="warn"] {
+  background: linear-gradient(90deg, #e9c987, #f0b86a);
+  box-shadow: 0 0 12px rgba(233,201,135,0.6);
+}
+.hud__health-fill[data-lvl="low"] {
+  background: linear-gradient(90deg, #e08aa8, #e0405a);
+  box-shadow: 0 0 14px rgba(224,64,90,0.7);
+  animation: hpPulse .6s ease-in-out infinite;
+}
+@keyframes hpPulse { 0%,100% { opacity: 1; } 50% { opacity: .5; } }
+.hud__stats {
+  display: flex; gap: 1.1rem;
+  font-family: var(--f-mono); font-size: .72rem; letter-spacing: .03em;
+  color: var(--text-dim); text-transform: uppercase;
+}
+.hud__stats b { color: var(--star); font-weight: 600; }
+
+/* achievement toasts */
+.toasts {
+  position: fixed; right: 1.1rem; top: 5rem; z-index: 120;
+  display: flex; flex-direction: column; gap: .55rem;
+  pointer-events: none; max-width: min(82vw, 320px);
+}
+.toast {
+  display: flex; align-items: center; gap: .7rem;
+  padding: .6rem .8rem; border-radius: 12px;
+  background: rgba(10,14,28,0.82); backdrop-filter: blur(12px);
+  border: 1px solid rgba(233,201,135,0.4);
+  box-shadow: 0 8px 30px rgba(0,0,0,0.45);
+  transform: translateX(120%); opacity: 0;
+  transition: transform .45s var(--ease), opacity .45s var(--ease);
+}
+.toast.in { transform: translateX(0); opacity: 1; }
+.toast__ico { font-size: 1.4rem; line-height: 1; filter: drop-shadow(0 0 6px rgba(233,201,135,0.6)); }
+.toast__txt { display: flex; flex-direction: column; line-height: 1.25; }
+.toast__txt b { color: var(--gold); font-size: .86rem; }
+.toast__txt span { color: var(--text-dim); font-size: .74rem; }
+
+/* game-over overlay */
+.gameover {
+  position: fixed; inset: 0; z-index: 200;
+  display: grid; place-items: center; padding: 1.4rem;
+  background: rgba(2,3,8,0.72); backdrop-filter: blur(6px);
+  opacity: 0; transition: opacity .4s ease; pointer-events: auto;
+}
+.gameover[hidden] { display: none !important; }
+.gameover.in { opacity: 1; }
+.gameover__panel {
+  width: min(92vw, 460px); padding: 1.8rem 1.6rem; text-align: center;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(22,15,58,0.9), rgba(11,15,32,0.92));
+  border: 1px solid var(--line); box-shadow: 0 30px 80px rgba(0,0,0,0.6);
+  transform: translateY(12px) scale(.98); transition: transform .45s var(--ease);
+}
+.gameover.in .gameover__panel { transform: none; }
+.gameover__title {
+  font-family: var(--f-display); font-weight: 600;
+  font-size: clamp(2rem, 7vw, 3rem); color: var(--star); line-height: 1; margin-bottom: .3rem;
+}
+.gameover__sub { color: var(--text-dim); font-style: italic; margin-bottom: 1.2rem; }
+.gameover__stats { display: grid; grid-template-columns: 1fr 1fr; gap: .7rem; margin-bottom: 1.1rem; }
+.gostat {
+  padding: .7rem; border-radius: 12px;
+  background: rgba(255,255,255,0.04); border: 1px solid var(--line-soft);
+}
+.gostat b { display: block; font-family: var(--f-mono); font-size: 1.3rem; color: var(--star); }
+.gostat span { font-size: .68rem; text-transform: uppercase; letter-spacing: .04em; color: var(--text-mute); }
+.gostat.is-best { border-color: rgba(233,201,135,0.5); box-shadow: 0 0 18px rgba(233,201,135,0.18); }
+.gostat em { display: block; color: var(--gold); font-style: normal; font-size: .58rem; margin-top: .15rem; letter-spacing: .08em; }
+.gameover__ach { margin-bottom: 1.3rem; }
+.gameover__ach-title {
+  font-size: .72rem; text-transform: uppercase; letter-spacing: .05em;
+  color: var(--text-mute); margin-bottom: .5rem;
+}
+.gameover__chips { display: flex; flex-wrap: wrap; gap: .4rem; justify-content: center; }
+.chip {
+  font-size: .72rem; padding: .3rem .55rem; border-radius: 999px;
+  background: rgba(233,201,135,0.12); border: 1px solid rgba(233,201,135,0.3); color: var(--gold);
+}
+.gameover__actions { display: flex; gap: .7rem; justify-content: center; }
+.gameover__btn {
+  font-family: var(--f-body); font-size: .86rem; padding: .6rem 1.2rem;
+  border-radius: 999px; cursor: pointer; color: var(--text);
+  background: transparent; border: 1px solid var(--line);
+  transition: background .25s, border-color .25s, color .25s, box-shadow .25s;
+}
+.gameover__btn:hover { border-color: var(--cyan); color: var(--star); }
+.gameover__btn--go { background: var(--cyan); color: #062028; border-color: var(--cyan); font-weight: 600; }
+.gameover__btn--go:hover { background: #9be4f2; color: #062028; box-shadow: 0 0 18px rgba(127,214,232,0.5); }
+
+@media (prefers-reduced-motion: reduce) {
+  .toast, .gameover, .gameover__panel { transition: none; }
+  .hud__health-fill[data-lvl="low"] { animation: none; }
+}
+
 @media (max-width: 880px) {
   .nav__links { display: none; }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -175,8 +175,11 @@
   }
 
   /* ============================================================
-     Flight mode — drive a rocket with WASD / arrows; flying past
-     the top or bottom of the comfort band scrolls the page.
+     Flight mode → COSMIC SKIRMISH — drive a rocket with WASD /
+     arrows (flying past the comfort band scrolls the page), shoot
+     with click or Space, and survive waves of alien saucers that
+     chase and fire back. Track survival time, kills, distance and
+     unlock achievements along the way.
      ============================================================ */
   (function flight() {
     const btn = document.getElementById("flyBtn");
@@ -185,6 +188,23 @@
     const dpad = document.getElementById("dpad");
     if (!btn || !rocket || !flame) return;
 
+    // game DOM
+    const gcanvas = document.getElementById("gameLayer");
+    const gctx = gcanvas ? gcanvas.getContext("2d") : null;
+    const hud = document.getElementById("hud");
+    const healthFill = document.getElementById("healthFill");
+    const hudTime = document.getElementById("hudTime");
+    const hudKills = document.getElementById("hudKills");
+    const toasts = document.getElementById("toasts");
+    const flash = document.getElementById("hitFlash");
+    const gameover = document.getElementById("gameover");
+    const goSub = document.getElementById("goSub");
+    const goStats = document.getElementById("goStats");
+    const goAch = document.getElementById("goAch");
+    const goAgain = document.getElementById("goAgain");
+    const goClose = document.getElementById("goClose");
+
+    // flight physics
     const ACCEL = 2200;     // px/s^2 of thrust
     const DAMP = 2.6;       // velocity damping per second
     const MAXV = 1100;      // px/s speed cap
@@ -192,10 +212,27 @@
     const BOOST_ACCEL = 2;  // thrust multiplier while Shift is held
     const BOOST_MAXV = 2100; // raised speed cap while boosting
 
+    // combat tuning
+    const MAXHP = 100;
+    const FIRE_CD = 0.16;      // seconds between player shots
+    const BULLET_V = 980;      // player bullet speed
+    const FOE_BULLET_V = 360;  // alien bullet speed
+    const isTouch = window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+
     let active = false;
-    let raf = 0, last = 0;
+    let raf = 0, last = 0, sp = 0;
     let px = 0, py = 0, vx = 0, vy = 0, rot = 0, thrust = 0;
-    const keys = { up: false, down: false, left: false, right: false, boost: false };
+    let gdpr = 1, gw = 0, gh = 0;
+    const keys = { up: false, down: false, left: false, right: false, boost: false, fire: false };
+
+    // run state
+    let hp, alive, dead;
+    let gTime, dist, kills, shots, hits, grazes, noHit, topSpeed, dmgTaken;
+    let reachedBottom, lowHpFlag, newBestTime, newBestKills;
+    let foes = [], pBullets = [], fBullets = [], parts = [];
+    let spawnT = 0, fireT = 0, shake = 0, shakeX = 0, shakeY = 0;
+    const unlocked = new Set();
+    const earned = [];
 
     const KEYMAP = {
       ArrowUp: "up", KeyW: "up",
@@ -204,6 +241,24 @@
       ArrowRight: "right", KeyD: "right",
     };
 
+    // achievements — checked every frame against a stats snapshot
+    const ACHS = [
+      { id: "firstblood",   icon: "💥", name: "First Blood",     desc: "Destroy your first alien",        test: s => s.kills >= 1 },
+      { id: "ace",          icon: "🎯", name: "Ace",             desc: "5 aliens down",                   test: s => s.kills >= 5 },
+      { id: "wipeout",      icon: "🛸", name: "Squadron Wiped",  desc: "15 aliens down",                  test: s => s.kills >= 15 },
+      { id: "annihilator",  icon: "☄️", name: "Annihilator",     desc: "30 aliens down",                  test: s => s.kills >= 30 },
+      { id: "survivor",     icon: "⏱️", name: "Survivor",        desc: "Stay alive for 30 seconds",       test: s => s.time >= 30 },
+      { id: "veteran",      icon: "🎖️", name: "Veteran",         desc: "Stay alive for 60 seconds",       test: s => s.time >= 60 },
+      { id: "untouchable",  icon: "✨", name: "Untouchable",     desc: "30 seconds without a scratch",    test: s => s.noHit >= 30 },
+      { id: "lightspeed",   icon: "⚡", name: "Ludicrous Speed", desc: "Hit afterburner top speed",       test: s => s.maxSpeed >= 2000 },
+      { id: "deepspace",    icon: "🌌", name: "Deep Space",      desc: "Fly 20,000 px",                   test: s => s.distance >= 20000 },
+      { id: "sharpshooter", icon: "🔭", name: "Sharpshooter",    desc: "70% accuracy (10+ shots)",        test: s => s.shotsFired >= 10 && s.shotsHit / s.shotsFired >= 0.7 },
+      { id: "graze",        icon: "🪡", name: "Close Shave",     desc: "Graze an enemy shot",             test: s => s.grazes >= 1 },
+      { id: "triggerhappy", icon: "🔫", name: "Trigger Happy",   desc: "Fire 100 shots",                  test: s => s.shotsFired >= 100 },
+      { id: "tothemoon",    icon: "🌕", name: "To The Moon",     desc: "Fly to the bottom of the page",   test: s => s.reachedBottom },
+      { id: "glasscannon",  icon: "🔥", name: "Glass Cannon",    desc: "Survive a hit under 15 hull",     test: s => s.lowHealthSurvived },
+    ];
+
     function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
 
     function lerpAngle(a, b, t) {
@@ -211,8 +266,342 @@
       return a + d * t;
     }
 
+    /* ---- tiny WebAudio blips (created on first gesture) ---- */
+    let actx = null;
+    function audio() {
+      if (!actx) { try { actx = new (window.AudioContext || window.webkitAudioContext)(); } catch (e) { actx = null; } }
+      return actx;
+    }
+    function beep(freq, dur, type, vol, slideTo) {
+      const a = audio();
+      if (!a) return;
+      try {
+        const o = a.createOscillator(), g = a.createGain();
+        o.type = type || "square";
+        o.frequency.setValueAtTime(freq, a.currentTime);
+        if (slideTo) o.frequency.exponentialRampToValueAtTime(Math.max(1, slideTo), a.currentTime + dur);
+        g.gain.setValueAtTime(vol || 0.04, a.currentTime);
+        g.gain.exponentialRampToValueAtTime(0.0001, a.currentTime + dur);
+        o.connect(g).connect(a.destination);
+        o.start();
+        o.stop(a.currentTime + dur);
+      } catch (e) { /* ignore */ }
+    }
+
+    /* ---- particles / explosions ---- */
+    const HUES = { gold: "233,201,135", rose: "224,138,168", cyan: "127,214,232", white: "244,241,255" };
+    function explode(x, y, hue, n) {
+      const rgb = HUES[hue] || HUES.white;
+      for (let k = 0; k < n; k++) {
+        const a = Math.random() * 6.2832, s = 40 + Math.random() * 260;
+        const life = 0.4 + Math.random() * 0.6;
+        parts.push({ x, y, vx: Math.cos(a) * s, vy: Math.sin(a) * s, r: 1 + Math.random() * 2.6, life, max: life, color: `rgba(${rgb},1)` });
+      }
+    }
+
+    function flashHit(intensity) {
+      if (!flash || reduceMotion) return;
+      flash.style.opacity = String(Math.min(0.55, intensity));
+      requestAnimationFrame(() => { flash.style.opacity = "0"; });
+    }
+
+    /* ---- spawning & firing ---- */
+    function spawnFoe() {
+      const m = 60, edge = Math.floor(Math.random() * 4);
+      let x, y;
+      if (edge === 0) { x = Math.random() * gw; y = -m; }
+      else if (edge === 1) { x = gw + m; y = Math.random() * gh; }
+      else if (edge === 2) { x = Math.random() * gw; y = gh + m; }
+      else { x = -m; y = Math.random() * gh; }
+      const tough = Math.random() < Math.min(0.4, gTime * 0.006);
+      foes.push({ x, y, vx: 0, vy: 0, r: tough ? 21 : 15, hp: tough ? 3 : 1, hue: tough ? "gold" : "rose", shoot: 0.8 + Math.random() * 1.4, wob: Math.random() * 6.2832 });
+    }
+
+    function tryShoot() {
+      if (!alive || fireT > 0) return;
+      fireT = FIRE_CD;
+      shots++;
+      const rad = rot * Math.PI / 180;
+      const dx = Math.sin(rad), dy = -Math.cos(rad);
+      pBullets.push({ x: px + dx * 28, y: py + dy * 28, vx: dx * BULLET_V + vx * 0.3, vy: dy * BULLET_V + vy * 0.3, life: 1.1 });
+      vx -= dx * 26; vy -= dy * 26;            // gentle recoil
+      beep(660, 0.07, "square", 0.025, 240);
+    }
+
+    /* ---- damage / death ---- */
+    function hitPlayer(dmg) {
+      if (!alive) return;
+      hp -= dmg; dmgTaken += dmg; noHit = 0;
+      shake = Math.max(shake, dmg * 0.4 + 5);
+      flashHit(dmg / 40);
+      beep(120, 0.18, "sawtooth", 0.05, 40);
+      if (hp <= 0) { hp = 0; die(); }
+      else if (hp <= 15) { lowHpFlag = true; }
+    }
+
+    function die() {
+      if (dead) return;
+      dead = true; alive = false;
+      explode(px, py, "gold", 40); explode(px, py, "rose", 26); explode(px, py, "white", 16);
+      shake = 18;
+      rocket.hidden = true;
+      keys.up = keys.down = keys.left = keys.right = keys.boost = keys.fire = false;
+      beep(90, 0.6, "sawtooth", 0.09, 30);
+      saveBest();
+      setTimeout(() => { if (active && dead) showOverlay(); }, 850);
+    }
+
+    /* ---- high scores ---- */
+    function saveBest() {
+      try {
+        const bt = parseFloat(localStorage.getItem("tm_bestTime") || "0");
+        const bk = parseInt(localStorage.getItem("tm_bestKills") || "0", 10);
+        if (gTime > bt) { localStorage.setItem("tm_bestTime", gTime.toFixed(1)); newBestTime = true; }
+        if (kills > bk) { localStorage.setItem("tm_bestKills", String(kills)); newBestKills = true; }
+      } catch (e) { /* ignore */ }
+    }
+
+    /* ---- achievements ---- */
+    function checkAch() {
+      const snap = {
+        kills, time: gTime, noHit, maxSpeed: topSpeed, distance: dist,
+        shotsFired: shots, shotsHit: hits, grazes, reachedBottom, lowHealthSurvived: lowHpFlag,
+      };
+      for (const a of ACHS) {
+        if (!unlocked.has(a.id) && a.test(snap)) {
+          unlocked.add(a.id);
+          earned.push(a);
+          toast(a);
+          beep(740, 0.1, "sine", 0.04, 1180);
+        }
+      }
+    }
+
+    function toast(a) {
+      if (!toasts) return;
+      const el = document.createElement("div");
+      el.className = "toast";
+      el.innerHTML = `<span class="toast__ico">${a.icon}</span><span class="toast__txt"><b>${a.name}</b><span>${a.desc}</span></span>`;
+      toasts.appendChild(el);
+      requestAnimationFrame(() => el.classList.add("in"));
+      setTimeout(() => { el.classList.remove("in"); setTimeout(() => el.remove(), 450); }, 3400);
+    }
+
+    /* ---- HUD ---- */
+    function updateHud() {
+      if (healthFill) {
+        healthFill.style.width = Math.max(0, hp) + "%";
+        healthFill.setAttribute("data-lvl", hp > 50 ? "ok" : hp > 22 ? "warn" : "low");
+      }
+      if (hudTime) hudTime.textContent = gTime.toFixed(1) + "s";
+      if (hudKills) hudKills.textContent = String(kills);
+    }
+
+    /* ---- game-over overlay ---- */
+    function statCard(label, val, best) {
+      return `<div class="gostat${best ? " is-best" : ""}"><b>${val}</b><span>${label}${best ? " <em>NEW BEST</em>" : ""}</span></div>`;
+    }
+    function showOverlay() {
+      if (!gameover) return;
+      const acc = shots > 0 ? Math.round(hits / shots * 100) : 0;
+      if (goSub) {
+        const tier = gTime < 10
+          ? ["Barely cleared the launch pad.", "Space is unforgiving."]
+          : gTime < 30
+            ? ["A respectable run.", "You held your own out there."]
+            : gTime < 60
+              ? ["Now that’s some flying.", "The aliens will remember you."]
+              : ["Absolute legend of the void.", "They’re writing songs about this run."];
+        goSub.textContent = tier[Math.floor(Math.random() * tier.length)];
+      }
+      if (goStats) {
+        goStats.innerHTML =
+          statCard("Survived", gTime.toFixed(1) + "s", newBestTime) +
+          statCard("Aliens destroyed", String(kills), newBestKills) +
+          statCard("Accuracy", acc + "%", false) +
+          statCard("Distance", Math.round(dist).toLocaleString() + " px", false);
+      }
+      if (goAch) {
+        if (earned.length) {
+          goAch.innerHTML =
+            `<div class="gameover__ach-title">Medals earned (${earned.length}/${ACHS.length})</div>` +
+            `<div class="gameover__chips">${earned.map(a => `<span class="chip" title="${a.desc}">${a.icon} ${a.name}</span>`).join("")}</div>`;
+        } else {
+          goAch.innerHTML = `<div class="gameover__ach-title">No medals this run — get back out there.</div>`;
+        }
+      }
+      gameover.hidden = false;
+      requestAnimationFrame(() => gameover.classList.add("in"));
+    }
+
+    /* ---- main game update ---- */
+    function updateGame(dt) {
+      if (alive) {
+        gTime += dt;
+        dist += sp * dt;
+        noHit += dt;
+        if (sp > topSpeed) topSpeed = sp;
+        if (!reachedBottom && window.scrollY + innerHeight >= document.documentElement.scrollHeight - 3) reachedBottom = true;
+        if (keys.fire || isTouch) tryShoot();
+
+        spawnT -= dt;
+        const maxFoes = Math.min(11, 3 + Math.floor(gTime / 11));
+        const interval = Math.max(0.55, 2.1 - gTime * 0.028);
+        if (foes.length < maxFoes && spawnT <= 0) { spawnFoe(); spawnT = interval; }
+      }
+      fireT -= dt;
+
+      const foeSpeed = Math.min(330, 150 + gTime * 2.4);
+      for (let i = foes.length - 1; i >= 0; i--) {
+        const f = foes[i];
+        f.wob += dt * 2.2;
+        const dx = px - f.x, dy = py - f.y, d = Math.hypot(dx, dy) || 1;
+        f.vx += (dx / d) * 620 * dt + Math.cos(f.wob) * 40 * dt;
+        f.vy += (dy / d) * 620 * dt + Math.sin(f.wob) * 40 * dt;
+        const fs = Math.hypot(f.vx, f.vy);
+        if (fs > foeSpeed) { f.vx = f.vx / fs * foeSpeed; f.vy = f.vy / fs * foeSpeed; }
+        f.x += f.vx * dt; f.y += f.vy * dt;
+
+        f.shoot -= dt;
+        if (alive && d < 1100 && f.shoot <= 0) {
+          f.shoot = 1.3 + Math.random() * 1.6;
+          const a = Math.atan2(dy, dx) + (Math.random() - 0.5) * 0.25;
+          fBullets.push({ x: f.x, y: f.y, vx: Math.cos(a) * FOE_BULLET_V, vy: Math.sin(a) * FOE_BULLET_V, life: 3.4 });
+          beep(170, 0.12, "sawtooth", 0.016, 90);
+        }
+
+        if (alive && d < f.r + 14) {              // rammed the player
+          explode(f.x, f.y, f.hue, 18);
+          foes.splice(i, 1); kills++;
+          hitPlayer(22);
+          beep(300, 0.22, "triangle", 0.04, 60);
+        }
+      }
+
+      // player bullets
+      for (let i = pBullets.length - 1; i >= 0; i--) {
+        const b = pBullets[i];
+        b.x += b.vx * dt; b.y += b.vy * dt; b.life -= dt;
+        let gone = b.life <= 0 || b.x < -30 || b.x > gw + 30 || b.y < -30 || b.y > gh + 30;
+        for (let j = foes.length - 1; j >= 0 && !gone; j--) {
+          const f = foes[j];
+          if (Math.hypot(b.x - f.x, b.y - f.y) < f.r + 5) {
+            f.hp--; hits++; gone = true;
+            explode(b.x, b.y, "cyan", 5);
+            if (f.hp <= 0) {
+              explode(f.x, f.y, f.hue, 20);
+              foes.splice(j, 1); kills++;
+              beep(300, 0.22, "triangle", 0.045, 70);
+            } else {
+              beep(520, 0.05, "square", 0.02, 380);
+            }
+          }
+        }
+        if (gone) pBullets.splice(i, 1);
+      }
+
+      // alien bullets
+      for (let i = fBullets.length - 1; i >= 0; i--) {
+        const b = fBullets[i];
+        b.x += b.vx * dt; b.y += b.vy * dt; b.life -= dt;
+        const d = Math.hypot(b.x - px, b.y - py);
+        if (alive && d < 14) { fBullets.splice(i, 1); hitPlayer(10); continue; }
+        if (alive && !b.grazed && d < 34) { b.grazed = true; grazes++; }
+        if (b.life <= 0 || b.x < -40 || b.x > gw + 40 || b.y < -40 || b.y > gh + 40) fBullets.splice(i, 1);
+      }
+
+      // particles
+      for (let i = parts.length - 1; i >= 0; i--) {
+        const p = parts[i];
+        p.x += p.vx * dt; p.y += p.vy * dt; p.vx *= 0.96; p.vy *= 0.96; p.life -= dt;
+        if (p.life <= 0) parts.splice(i, 1);
+      }
+
+      // screen shake decay
+      if (shake > 0) { shake = Math.max(0, shake - dt * 36); shakeX = (Math.random() - 0.5) * shake; shakeY = (Math.random() - 0.5) * shake; }
+      else { shakeX = 0; shakeY = 0; }
+    }
+
+    /* ---- rendering ---- */
+    function drawFoe(f) {
+      const rgb = HUES[f.hue] || HUES.rose, R = f.r;
+      gctx.save();
+      gctx.translate(f.x, f.y);
+      gctx.rotate(Math.sin(f.wob) * 0.18);
+      const gl = gctx.createRadialGradient(0, 0, 0, 0, 0, R * 2.4);
+      gl.addColorStop(0, `rgba(${rgb},0.32)`);
+      gl.addColorStop(1, `rgba(${rgb},0)`);
+      gctx.fillStyle = gl;
+      gctx.beginPath(); gctx.arc(0, 0, R * 2.4, 0, 6.2832); gctx.fill();
+      // saucer
+      gctx.beginPath();
+      gctx.ellipse(0, R * 0.18, R * 1.5, R * 0.55, 0, 0, 6.2832);
+      gctx.fillStyle = `rgb(${rgb})`; gctx.fill();
+      gctx.lineWidth = 1.4; gctx.strokeStyle = "rgba(11,15,32,0.5)"; gctx.stroke();
+      // dome
+      gctx.beginPath();
+      gctx.ellipse(0, -R * 0.12, R * 0.7, R * 0.62, 0, Math.PI, 0);
+      const dg = gctx.createLinearGradient(0, -R * 0.8, 0, 0);
+      dg.addColorStop(0, "rgba(214,246,255,0.95)");
+      dg.addColorStop(1, "rgba(127,214,232,0.6)");
+      gctx.fillStyle = dg; gctx.fill();
+      gctx.strokeStyle = "rgba(11,15,32,0.45)"; gctx.stroke();
+      // eye
+      gctx.fillStyle = "rgba(11,15,32,0.85)";
+      gctx.beginPath(); gctx.ellipse(0, -R * 0.2, R * 0.18, R * 0.26, 0, 0, 6.2832); gctx.fill();
+      // belly lights
+      for (let i = -1; i <= 1; i++) {
+        const blink = Math.sin(f.wob * 3 + i) * 0.5 + 0.5;
+        gctx.beginPath(); gctx.arc(i * R * 0.7, R * 0.32, R * 0.13, 0, 6.2832);
+        gctx.fillStyle = `rgba(255,246,216,${0.35 + blink * 0.6})`; gctx.fill();
+      }
+      gctx.restore();
+    }
+
+    function drawGame() {
+      if (!gctx) return;
+      gctx.setTransform(gdpr, 0, 0, gdpr, 0, 0);
+      gctx.clearRect(0, 0, gw, gh);
+      gctx.save();
+      gctx.translate(shakeX, shakeY);
+
+      for (const b of fBullets) {
+        const g = gctx.createRadialGradient(b.x, b.y, 0, b.x, b.y, 9);
+        g.addColorStop(0, "rgba(255,210,230,0.95)");
+        g.addColorStop(0.4, "rgba(224,138,168,0.9)");
+        g.addColorStop(1, "rgba(224,138,168,0)");
+        gctx.fillStyle = g;
+        gctx.beginPath(); gctx.arc(b.x, b.y, 9, 0, 6.2832); gctx.fill();
+        gctx.fillStyle = "#fff";
+        gctx.beginPath(); gctx.arc(b.x, b.y, 2.2, 0, 6.2832); gctx.fill();
+      }
+
+      gctx.lineWidth = 3.2; gctx.lineCap = "round";
+      for (const b of pBullets) {
+        const ang = Math.atan2(b.vy, b.vx), len = 16;
+        const tx = b.x - Math.cos(ang) * len, ty = b.y - Math.sin(ang) * len;
+        const g = gctx.createLinearGradient(b.x, b.y, tx, ty);
+        g.addColorStop(0, "rgba(255,246,216,1)");
+        g.addColorStop(0.5, "rgba(127,214,232,0.9)");
+        g.addColorStop(1, "rgba(127,214,232,0)");
+        gctx.strokeStyle = g;
+        gctx.beginPath(); gctx.moveTo(b.x, b.y); gctx.lineTo(tx, ty); gctx.stroke();
+      }
+
+      for (const f of foes) drawFoe(f);
+
+      for (const p of parts) {
+        gctx.globalAlpha = Math.max(0, p.life / p.max);
+        gctx.fillStyle = p.color;
+        gctx.beginPath(); gctx.arc(p.x, p.y, p.r, 0, 6.2832); gctx.fill();
+      }
+      gctx.globalAlpha = 1;
+      gctx.restore();
+    }
+
     function render() {
-      rocket.style.transform = `translate3d(${px.toFixed(1)}px, ${py.toFixed(1)}px, 0) rotate(${rot.toFixed(2)}deg)`;
+      const sx = px + shakeX, sy = py + shakeY;
+      rocket.style.transform = `translate3d(${sx.toFixed(1)}px, ${sy.toFixed(1)}px, 0) rotate(${rot.toFixed(2)}deg)`;
       flame.style.setProperty("--thrust", thrust.toFixed(3));
     }
 
@@ -220,75 +609,108 @@
       const dt = Math.min((now - last) / 1000, 0.05);
       last = now;
 
-      const ax = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
-      const ay = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
-      const boosting = keys.boost && (ax !== 0 || ay !== 0);
+      if (alive) {
+        const ax = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
+        const ay = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
+        const boosting = keys.boost && (ax !== 0 || ay !== 0);
 
-      const accel = ACCEL * (keys.boost ? BOOST_ACCEL : 1);
-      vx += ax * accel * dt;
-      vy += ay * accel * dt;
+        const accel = ACCEL * (keys.boost ? BOOST_ACCEL : 1);
+        vx += ax * accel * dt;
+        vy += ay * accel * dt;
 
-      // exponential damping toward rest
-      const damp = Math.exp(-DAMP * dt);
-      vx *= damp; vy *= damp;
+        const damp = Math.exp(-DAMP * dt);
+        vx *= damp; vy *= damp;
 
-      // speed cap (raised while boosting)
-      const maxv = keys.boost ? BOOST_MAXV : MAXV;
-      const sp = Math.hypot(vx, vy);
-      if (sp > maxv) { vx = vx / sp * maxv; vy = vy / sp * maxv; }
-      rocket.classList.toggle("is-boosting", boosting);
+        const maxv = keys.boost ? BOOST_MAXV : MAXV;
+        sp = Math.hypot(vx, vy);
+        if (sp > maxv) { vx = vx / sp * maxv; vy = vy / sp * maxv; sp = maxv; }
+        rocket.classList.toggle("is-boosting", boosting);
 
-      // horizontal: move within the viewport, soft-bounce off the sides
-      px += vx * dt;
-      const xMin = MARGIN, xMax = innerWidth - MARGIN;
-      if (px < xMin) { px = xMin; vx = Math.abs(vx) * 0.4; }
-      else if (px > xMax) { px = xMax; vx = -Math.abs(vx) * 0.4; }
+        // horizontal: move within the viewport, soft-bounce off the sides
+        px += vx * dt;
+        const xMin = MARGIN, xMax = innerWidth - MARGIN;
+        if (px < xMin) { px = xMin; vx = Math.abs(vx) * 0.4; }
+        else if (px > xMax) { px = xMax; vx = -Math.abs(vx) * 0.4; }
 
-      // vertical: stay inside the band; overflow drives the page scroll.
-      py += vy * dt;
-      const yMin = MARGIN, yMax = innerHeight - MARGIN;
-      if (py > yMax) {
-        const over = py - yMax;
-        const before = window.scrollY;
-        window.scrollBy(0, over);
-        const moved = window.scrollY - before;
-        py = yMax + (over - moved);           // leftover (page bottom) pushes rocket to the edge
-        if (moved < over - 0.5) vy *= 0.6;
-      } else if (py < yMin) {
-        const over = yMin - py;
-        const before = window.scrollY;
-        window.scrollBy(0, -over);
-        const moved = before - window.scrollY;
-        py = yMin - (over - moved);
-        if (moved < over - 0.5) vy *= 0.6;
+        // vertical: stay inside the band; overflow drives the page scroll.
+        py += vy * dt;
+        const yMin = MARGIN, yMax = innerHeight - MARGIN;
+        if (py > yMax) {
+          const over = py - yMax;
+          const before = window.scrollY;
+          window.scrollBy(0, over);
+          const moved = window.scrollY - before;
+          py = yMax + (over - moved);
+          if (moved < over - 0.5) vy *= 0.6;
+        } else if (py < yMin) {
+          const over = yMin - py;
+          const before = window.scrollY;
+          window.scrollBy(0, -over);
+          const moved = before - window.scrollY;
+          py = yMin - (over - moved);
+          if (moved < over - 0.5) vy *= 0.6;
+        }
+        py = clamp(py, 6, innerHeight - 6);
+
+        if (sp > 40) {
+          const targetRot = Math.atan2(vx, -vy) * 180 / Math.PI;
+          rot = lerpAngle(rot, targetRot, 0.2);
+        }
+        let wantThrust = clamp((Math.abs(ax) + Math.abs(ay)) * 0.7 + sp / MAXV * 0.6, 0, 1);
+        if (boosting) wantThrust = 1.4;
+        thrust += (wantThrust - thrust) * 0.25;
+      } else {
+        sp = Math.hypot(vx, vy);
+        thrust += (0 - thrust) * 0.1;
       }
-      py = clamp(py, 6, innerHeight - 6);
 
-      // point the nose along the direction of travel (nose-up = 0deg);
-      // hold the last heading when nearly stopped to avoid jitter.
-      if (sp > 40) {
-        const targetRot = Math.atan2(vx, -vy) * 180 / Math.PI;
-        rot = lerpAngle(rot, targetRot, 0.2);
-      }
-      let wantThrust = clamp((Math.abs(ax) + Math.abs(ay)) * 0.7 + sp / MAXV * 0.6, 0, 1);
-      if (boosting) wantThrust = 1.4;          // afterburner flare
-      thrust += (wantThrust - thrust) * 0.25;
-
-      render();
+      updateGame(dt);
+      checkAch();
+      updateHud();
+      if (alive) render();
+      drawGame();
       raf = requestAnimationFrame(step);
+    }
+
+    function sizeGame() {
+      if (!gcanvas) return;
+      gdpr = Math.min(window.devicePixelRatio || 1, 2);
+      gw = innerWidth; gh = innerHeight;
+      gcanvas.width = Math.floor(gw * gdpr);
+      gcanvas.height = Math.floor(gh * gdpr);
+      gcanvas.style.width = gw + "px";
+      gcanvas.style.height = gh + "px";
+    }
+
+    function resetGame() {
+      px = innerWidth / 2; py = innerHeight - MARGIN;
+      vx = 0; vy = -MAXV * 0.5; rot = 0; thrust = 1;
+      hp = MAXHP; alive = true; dead = false;
+      gTime = 0; dist = 0; kills = 0; shots = 0; hits = 0; grazes = 0;
+      noHit = 0; topSpeed = 0; dmgTaken = 0;
+      reachedBottom = false; lowHpFlag = false; newBestTime = false; newBestKills = false;
+      foes = []; pBullets = []; fBullets = []; parts = [];
+      spawnT = 0.6; fireT = 0; shake = 0; shakeX = 0; shakeY = 0;
+      unlocked.clear(); earned.length = 0;
+      keys.up = keys.down = keys.left = keys.right = keys.boost = keys.fire = false;
+      rocket.hidden = false;
+      if (gameover) { gameover.hidden = true; gameover.classList.remove("in"); }
+      if (toasts) toasts.innerHTML = "";
+      if (flash) flash.style.opacity = "0";
     }
 
     function start() {
       if (active) return;
       active = true;
-      px = innerWidth / 2;
-      py = innerHeight - MARGIN;        // launch from near the bottom
-      vx = 0; vy = -MAXV * 0.5; rot = 0; thrust = 1;
-      rocket.hidden = false;
+      sizeGame();
+      resetGame();
+      try { audio(); if (actx && actx.state === "suspended") actx.resume(); } catch (e) { /* ignore */ }
+      if (gcanvas) gcanvas.hidden = false;
+      if (hud) hud.hidden = false;
       if (dpad) { dpad.hidden = false; dpad.classList.add("is-on"); }
       document.documentElement.classList.add("flying");
       btn.setAttribute("aria-pressed", "true");
-      render();
+      updateHud(); render(); drawGame();
       last = performance.now();
       raf = requestAnimationFrame(step);
     }
@@ -297,31 +719,53 @@
       if (!active) return;
       active = false;
       cancelAnimationFrame(raf);
-      keys.up = keys.down = keys.left = keys.right = keys.boost = false;
+      keys.up = keys.down = keys.left = keys.right = keys.boost = keys.fire = false;
       rocket.classList.remove("is-boosting");
       rocket.hidden = true;
       if (dpad) { dpad.hidden = true; dpad.classList.remove("is-on"); }
+      if (gcanvas) { gcanvas.hidden = true; if (gctx) { gctx.setTransform(1, 0, 0, 1, 0, 0); gctx.clearRect(0, 0, gcanvas.width, gcanvas.height); } }
+      if (hud) hud.hidden = true;
+      if (gameover) { gameover.hidden = true; gameover.classList.remove("in"); }
+      if (toasts) toasts.innerHTML = "";
+      if (flash) flash.style.opacity = "0";
       document.documentElement.classList.remove("flying");
       btn.setAttribute("aria-pressed", "false");
+    }
+
+    function again() {
+      if (!active) { start(); return; }
+      resetGame();
+      updateHud();
     }
 
     function toggle() { active ? stop() : start(); }
 
     btn.addEventListener("click", toggle);
+    if (goAgain) goAgain.addEventListener("click", again);
+    if (goClose) goClose.addEventListener("click", stop);
 
     window.addEventListener("keydown", (e) => {
       if (e.key === "Escape" && active) { stop(); return; }
       if (!active) return;
+      if (e.code === "Space") { keys.fire = true; e.preventDefault(); return; }
       if (e.key === "Shift") { keys.boost = true; return; }
       const dir = KEYMAP[e.code];
       if (!dir) return;
       keys[dir] = true;
-      e.preventDefault();                // stop arrows/space from scrolling on their own
+      e.preventDefault();                // stop arrows from scrolling on their own
     });
     window.addEventListener("keyup", (e) => {
+      if (e.code === "Space") { keys.fire = false; return; }
       if (e.key === "Shift") keys.boost = false;
       const dir = KEYMAP[e.code];
       if (dir) keys[dir] = false;
+    });
+
+    // click / tap to shoot (ignore clicks on UI chrome)
+    window.addEventListener("mousedown", (e) => {
+      if (!active || dead) return;
+      if (e.target.closest(".nav, .dpad, .gameover, button, a")) return;
+      tryShoot();
     });
 
     // on-screen d-pad for touch
@@ -337,9 +781,10 @@
       });
     }
 
-    // if the window shrinks, keep the rocket on screen
+    // keep things on screen / sized when the window changes
     window.addEventListener("resize", () => {
       if (!active) return;
+      sizeGame();
       px = clamp(px, MARGIN, innerWidth - MARGIN);
       py = clamp(py, MARGIN, innerHeight - MARGIN);
     }, { passive: true });

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <a href="#contact">Contact</a>
   </nav>
   <div class="nav__actions">
-    <button type="button" class="nav__fly" id="flyBtn" aria-pressed="false" aria-label="Fly a rocket" title="Fly a rocket — WASD or arrow keys">
+    <button type="button" class="nav__fly" id="flyBtn" aria-pressed="false" aria-label="Fly a rocket and fight aliens" title="Fly &amp; fight — WASD/arrows to move, click or Space to shoot, Shift to boost">
       <span class="nav__fly-ico" aria-hidden="true">🚀</span>
     </button>
     <a href="#contact" class="nav__cta">Available</a>
@@ -84,6 +84,37 @@
   <button class="dpad__btn dpad__left"  data-dir="left">◀</button>
   <button class="dpad__btn dpad__right" data-dir="right">▶</button>
   <button class="dpad__btn dpad__down"  data-dir="down">▼</button>
+</div>
+
+<!-- ============ GAME (combat layer · HUD · achievements) ============ -->
+<canvas class="game-layer" id="gameLayer" hidden aria-hidden="true"></canvas>
+<div class="hit-flash" id="hitFlash" aria-hidden="true"></div>
+
+<div class="hud" id="hud" hidden aria-hidden="true">
+  <div class="hud__bar">
+    <div class="hud__health" title="Hull integrity">
+      <span class="hud__health-fill" id="healthFill" data-lvl="ok"></span>
+    </div>
+    <div class="hud__stats">
+      <span><b id="hudTime">0.0s</b> alive</span>
+      <span><b id="hudKills">0</b> kills</span>
+    </div>
+  </div>
+</div>
+
+<div class="toasts" id="toasts" aria-live="polite" aria-atomic="false"></div>
+
+<div class="gameover" id="gameover" hidden aria-hidden="true">
+  <div class="gameover__panel" role="dialog" aria-label="Game over">
+    <h2 class="gameover__title">You blew up</h2>
+    <p class="gameover__sub" id="goSub"></p>
+    <div class="gameover__stats" id="goStats"></div>
+    <div class="gameover__ach" id="goAch"></div>
+    <div class="gameover__actions">
+      <button type="button" class="gameover__btn gameover__btn--go" id="goAgain">Fly again</button>
+      <button type="button" class="gameover__btn" id="goClose">Done</button>
+    </div>
+  </div>
 </div>
 
 <main>


### PR DESCRIPTION
Turns the existing rocket flight mode into a little arcade game: **Cosmic Skirmish**. Alien saucers chase and shoot at you, you shoot back, you have health, and you blow up when it runs out. Survival time / kills are tracked, and achievements unlock as you fly.

## What's new

**Combat**
- Alien saucers spawn from the screen edges, chase the player, and fire plasma. Tougher gold saucers (3 HP) appear as the run gets older.
- Shoot with **click** or **Space** (auto-fires on touch). Bullets fire from the nose with a small recoil kick.
- **Hull health** bar (green → gold → pulsing red). Alien shots chip you, ramming hurts. At 0 the rocket explodes.

**Scoring & achievements**
- HUD shows live **time survived** and **kills**.
- 14 achievements toast in during play — kills (First Blood → Annihilator), survival time, Untouchable (no-damage streak), accuracy, distance, top speed, grazes, To The Moon, Glass Cannon, etc.
- Game-over overlay with run stats (time, kills, accuracy, distance), earned medals, and `localStorage` best-time/best-kills with **NEW BEST** badges.

**Game feel**: WebAudio blips (shoot/hit/explode/achievement), particle explosions, hit-flash vignette, and screen shake.

The original fly-to-scroll, Shift boost, on-screen d-pad, and Esc-to-quit all still work — combat layers on top.

## Files
- `index.html` — combat canvas, HUD, toast container, hit-flash, game-over overlay
- `assets/css/styles.css` — HUD/health bar, toasts, game-over panel, hit-flash (cosmic palette)
- `assets/js/main.js` — extended the `flight()` module with the full game

## Testing
Driven end-to-end in a headless Chromium via CDP: start → combat → health depletion → death → game-over overlay (stats + medals + NEW BEST) → "Fly again" reset. No JS console errors at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)