### PR TITLE
Redesign experience section as frosted-glass elevation cards with detail modal

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -533,8 +533,7 @@ main, .nav, .foot { position: relative; z-index: 2; }
    EXPERIENCE — per-job scene backgrounds (the descent)
    ============================================================ */
 .entry { isolation: isolate; }
-.entry > *:not(.entry__bg) { position: relative; z-index: 1; }
-.entry::before { z-index: 1; }
+.entry > *:not(.entry__bg):not(.entry__detail) { position: relative; z-index: 1; }
 .entry__bg {
   position: absolute; top: 0; left: 50%; transform: translateX(-50%);
   width: 100vw; height: 100%; z-index: 0; overflow: hidden;
@@ -585,60 +584,120 @@ main, .nav, .foot { position: relative; z-index: 2; }
 }
 
 /* ============================================================
-   EXPERIENCE / TIMELINE
+   EXPERIENCE / TIMELINE — card layout
    ============================================================ */
-.timeline { list-style: none; position: relative; }
-.timeline::before {
-  content: ""; position: absolute; left: 0; top: .4rem; bottom: .4rem; width: 1px;
-  background: linear-gradient(180deg, transparent, var(--line) 8%, var(--line) 92%, transparent);
-}
-@media (max-width: 820px) { .timeline::before { display: none; } }
+.timeline { list-style: none; }
 
 .entry {
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  gap: clamp(1.5rem, 4vw, 4rem);
-  padding: 2.8rem 0 2.8rem 2.2rem;
-  border-bottom: 1px solid var(--line-soft);
   position: relative;
-}
-.entry::before {
-  content: ""; position: absolute; left: -4px; top: 3.4rem;
-  width: 9px; height: 9px; border-radius: 50%;
-  background: var(--gold); box-shadow: 0 0 12px var(--gold);
+  min-height: 20rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem var(--gut);
+  border-bottom: 1px solid var(--line-soft);
 }
 .entry:last-child { border-bottom: none; }
 
-.entry__meta { padding-top: .25rem; }
-.entry__no {
-  font-family: var(--f-display); font-size: 2.6rem; font-weight: 300;
-  font-style: italic; color: var(--text-mute); display: block; line-height: 1;
-  margin-bottom: .6rem;
+/* ---------- compact glass card ---------- */
+.entry__card {
+  position: relative; z-index: 1;
+  max-width: 560px; width: 100%;
+  padding: 1.6rem 1.8rem;
+  background: rgba(8, 11, 26, 0.42);
+  border: 1px solid rgba(233, 201, 135, 0.18);
+  border-radius: 16px;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  cursor: pointer;
+  text-align: left;
+  display: block;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  transition: border-color .3s var(--ease), background .3s, transform .25s var(--ease), box-shadow .3s;
 }
-.entry__date {
-  font-family: var(--f-mono); font-size: .76rem; letter-spacing: .06em;
+.entry__card:hover {
+  border-color: rgba(233, 201, 135, 0.42);
+  background: rgba(8, 11, 26, 0.62);
+  transform: translateY(-3px);
+  box-shadow: 0 18px 52px rgba(0, 0, 0, 0.55);
+}
+.entry__card:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 3px;
+}
+
+.entry__card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.9rem;
+}
+
+.entry__layer-badge {
+  font-family: var(--f-mono);
+  font-size: .68rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
   color: var(--cyan);
 }
+
+.entry__no {
+  font-family: var(--f-display); font-size: 2rem; font-weight: 300;
+  font-style: italic; color: var(--text-mute); line-height: 1;
+}
+
 .entry__org {
   font-family: var(--f-display); font-weight: 500;
-  font-size: clamp(1.7rem, 3.2vw, 2.5rem); line-height: 1.08;
-  color: var(--star); margin-bottom: .35rem;
+  font-size: clamp(1.5rem, 2.8vw, 2.1rem); line-height: 1.1;
+  color: var(--star); margin-bottom: .25rem;
 }
+
 .entry__role {
-  font-family: var(--f-mono); font-size: .82rem; letter-spacing: .03em;
-  color: var(--gold-soft); margin-bottom: 1.5rem;
+  font-family: var(--f-mono); font-size: .78rem; letter-spacing: .03em;
+  color: var(--gold-soft); margin-bottom: .7rem;
 }
-.entry__text p { color: var(--text-dim); margin-bottom: 1.1rem; font-size: 1.01rem; }
-.entry__text p:last-child { margin-bottom: 0; }
+
+.entry__summary {
+  color: var(--text-dim);
+  font-size: .97rem;
+  line-height: 1.55;
+  margin-bottom: .9rem;
+}
+
+.entry__card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: .75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.entry__date {
+  font-family: var(--f-mono); font-size: .74rem; letter-spacing: .06em;
+  color: var(--cyan);
+}
+
+.entry__open-hint {
+  font-family: var(--f-mono);
+  font-size: .68rem;
+  letter-spacing: .05em;
+  color: var(--gold);
+  opacity: .65;
+  transition: opacity .2s;
+}
+.entry__card:hover .entry__open-hint { opacity: 1; }
 
 @media (max-width: 820px) {
-  .entry { grid-template-columns: 1fr; gap: .9rem; padding-left: 0; }
-  .entry::before { display: none; }
-  .entry__meta { display: flex; align-items: baseline; gap: 1rem; }
-  .entry__no { font-size: 1.8rem; margin-bottom: 0; }
+  .entry { padding: 2.8rem 1.2rem; min-height: 16rem; }
+  .entry__card { max-width: 100%; }
+  .entry__card-foot { flex-direction: column; align-items: flex-start; gap: .4rem; }
+  .entry__no { font-size: 1.6rem; }
+  .entry__open-hint { opacity: 1; }
 }
 
-/* ---------- chips ---------- */
+/* ---------- chips (used in modal) ---------- */
 .chips {
   list-style: none; display: flex; flex-wrap: wrap; gap: .5rem;
   margin-top: 1.6rem;
@@ -651,6 +710,83 @@ main, .nav, .foot { position: relative; z-index: 2; }
   transition: border-color .25s, color .25s, background .25s;
 }
 .chips li:hover { border-color: rgba(233,201,135,0.4); color: var(--gold); background: rgba(233,201,135,0.06); }
+
+/* ============================================================
+   EXPERIENCE DETAIL MODAL
+   ============================================================ */
+.entry-modal {
+  position: fixed; inset: 0; z-index: 150;
+  display: grid; place-items: center; padding: 1.4rem;
+  background: rgba(2, 3, 8, 0.78); backdrop-filter: blur(8px);
+  opacity: 0; transition: opacity .35s ease; pointer-events: auto;
+}
+.entry-modal[hidden] { display: none !important; }
+.entry-modal.in { opacity: 1; }
+
+.entry-modal__panel {
+  position: relative;
+  width: min(94vw, 680px);
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 2.2rem 2.4rem;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(18, 12, 48, 0.96), rgba(8, 12, 26, 0.98));
+  border: 1px solid var(--line);
+  box-shadow: 0 40px 100px rgba(0, 0, 0, 0.7);
+  transform: translateY(14px) scale(.98);
+  transition: transform .4s var(--ease);
+  scrollbar-width: thin;
+  scrollbar-color: var(--line) transparent;
+}
+.entry-modal__panel::-webkit-scrollbar { width: 5px; }
+.entry-modal__panel::-webkit-scrollbar-track { background: transparent; }
+.entry-modal__panel::-webkit-scrollbar-thumb { background: var(--line); border-radius: 99px; }
+.entry-modal.in .entry-modal__panel { transform: none; }
+
+.entry-modal__close {
+  position: absolute; top: 1rem; right: 1.1rem;
+  width: 2rem; height: 2rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--line);
+  border-radius: 50%; cursor: pointer; color: var(--text-dim);
+  font-size: .9rem; line-height: 1;
+  display: flex; align-items: center; justify-content: center;
+  transition: background .2s, color .2s, border-color .2s;
+}
+.entry-modal__close:hover { background: rgba(255, 255, 255, 0.14); color: var(--star); border-color: rgba(160, 168, 220, 0.35); }
+
+.entry-modal__layer {
+  font-family: var(--f-mono); font-size: .7rem; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--cyan);
+  display: block; margin-bottom: .8rem;
+}
+.entry-modal__org {
+  font-family: var(--f-display); font-weight: 500;
+  font-size: clamp(1.6rem, 4vw, 2.4rem); line-height: 1.08;
+  color: var(--star); margin-bottom: .3rem;
+}
+.entry-modal__role {
+  font-family: var(--f-mono); font-size: .82rem; letter-spacing: .03em;
+  color: var(--gold-soft); margin-bottom: .3rem;
+}
+.entry-modal__date {
+  font-family: var(--f-mono); font-size: .76rem; letter-spacing: .06em;
+  color: var(--cyan); display: block; margin-bottom: 1.8rem;
+  padding-bottom: 1.4rem;
+  border-bottom: 1px solid var(--line-soft);
+}
+.entry-modal__body .entry__text p {
+  color: var(--text-dim); margin-bottom: 1.1rem; font-size: 1.01rem; line-height: 1.7;
+}
+.entry-modal__body .entry__text p:last-child { margin-bottom: 0; }
+.entry-modal__body .chips { margin-top: 1.6rem; }
+
+@media (max-width: 820px) {
+  .entry-modal__panel { padding: 1.8rem 1.4rem; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .entry-modal, .entry-modal__panel { transition: none; }
+}
 
 /* ============================================================
    EDUCATION

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -584,25 +584,73 @@ main, .nav, .foot { position: relative; z-index: 2; }
 }
 
 /* ============================================================
-   EXPERIENCE / TIMELINE — card layout
+   EXPERIENCE / TIMELINE — staggered card layout
    ============================================================ */
 .timeline { list-style: none; }
 
 .entry {
   position: relative;
-  min-height: 20rem;
+  min-height: 24rem;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 4rem var(--gut);
+  padding: 4.5rem var(--gut);
   border-bottom: 1px solid var(--line-soft);
+  overflow: hidden;
 }
 .entry:last-child { border-bottom: none; }
 
+/* Stagger: odd left-biased, even right-biased */
+.entry:nth-child(odd)  { justify-content: flex-start; }
+.entry:nth-child(even) { justify-content: flex-end; }
+
+/* Per-entry horizontal offset for organic, non-uniform stagger */
+.entry:nth-child(1) { padding-left:  max(var(--gut), 7vw);  }
+.entry:nth-child(2) { padding-right: max(var(--gut), 10vw); }
+.entry:nth-child(3) { padding-left:  max(var(--gut), 13vw); }
+.entry:nth-child(4) { padding-right: max(var(--gut), 5vw);  }
+.entry:nth-child(5) { padding-left:  max(var(--gut), 9vw);  }
+.entry:nth-child(6) { padding-right: max(var(--gut), 11vw); }
+
+/* ---------- scene group: SVG object + glass card ---------- */
+.entry__scene {
+  position: relative; z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+.entry:nth-child(odd)  .entry__scene { flex-direction: row; }
+.entry:nth-child(even) .entry__scene { flex-direction: row-reverse; }
+
+/* ---------- SVG/photo object ---------- */
+.entry__object {
+  flex-shrink: 0;
+  width: 148px; height: 148px;
+  border-radius: 14px;
+  background: rgba(8, 11, 26, 0.44);
+  border: 1px solid rgba(233, 201, 135, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  box-shadow: 0 4px 28px rgba(0, 0, 0, 0.55), 0 0 36px rgba(233, 201, 135, 0.05);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: border-color .3s var(--ease), box-shadow .3s;
+}
+.entry__object img {
+  width: 80%; height: 80%;
+  object-fit: contain;
+  display: block;
+}
+/* Glow the object frame when the card is hovered (modern CSS) */
+.entry__scene:has(.entry__card:hover) .entry__object {
+  border-color: rgba(233, 201, 135, 0.38);
+  box-shadow: 0 4px 28px rgba(0, 0, 0, 0.55), 0 0 44px rgba(233, 201, 135, 0.14);
+}
+
 /* ---------- compact glass card ---------- */
 .entry__card {
-  position: relative; z-index: 1;
-  max-width: 560px; width: 100%;
+  max-width: 500px; width: 100%;
   padding: 1.6rem 1.8rem;
   background: rgba(8, 11, 26, 0.42);
   border: 1px solid rgba(233, 201, 135, 0.18);
@@ -650,7 +698,7 @@ main, .nav, .foot { position: relative; z-index: 2; }
 
 .entry__org {
   font-family: var(--f-display); font-weight: 500;
-  font-size: clamp(1.5rem, 2.8vw, 2.1rem); line-height: 1.1;
+  font-size: clamp(1.4rem, 2.6vw, 2rem); line-height: 1.1;
   color: var(--star); margin-bottom: .25rem;
 }
 
@@ -661,7 +709,7 @@ main, .nav, .foot { position: relative; z-index: 2; }
 
 .entry__summary {
   color: var(--text-dim);
-  font-size: .97rem;
+  font-size: .96rem;
   line-height: 1.55;
   margin-bottom: .9rem;
 }
@@ -689,8 +737,23 @@ main, .nav, .foot { position: relative; z-index: 2; }
 }
 .entry__card:hover .entry__open-hint { opacity: 1; }
 
-@media (max-width: 820px) {
-  .entry { padding: 2.8rem 1.2rem; min-height: 16rem; }
+@media (max-width: 900px) {
+  .entry {
+    padding: 3.5rem var(--gut) !important;
+    justify-content: center !important;
+    min-height: 18rem;
+  }
+  .entry__scene {
+    flex-direction: column !important;
+    align-items: center;
+    gap: 1.4rem;
+  }
+  .entry__object { width: 120px; height: 120px; }
+  .entry__card { max-width: 480px; width: 100%; }
+}
+@media (max-width: 520px) {
+  .entry { padding: 2.5rem var(--gut) !important; min-height: 14rem; }
+  .entry__object { display: none; }
   .entry__card { max-width: 100%; }
   .entry__card-foot { flex-direction: column; align-items: flex-start; gap: .4rem; }
   .entry__no { font-size: 1.6rem; }
@@ -716,7 +779,7 @@ main, .nav, .foot { position: relative; z-index: 2; }
    ============================================================ */
 .entry-modal {
   position: fixed; inset: 0; z-index: 150;
-  display: grid; place-items: center; padding: 1.4rem;
+  display: flex; align-items: center; justify-content: center; padding: 1.2rem;
   background: rgba(2, 3, 8, 0.78); backdrop-filter: blur(8px);
   opacity: 0; transition: opacity .35s ease; pointer-events: auto;
 }

--- a/assets/img/objects/airliner.svg
+++ b/assets/img/objects/airliner.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 290 100">
+  <!-- fuselage -->
+  <path d="M 5,50 C 28,34 55,28 95,26 L 228,26 C 252,26 268,36 276,50 C 268,64 252,74 228,74 L 95,74 C 55,72 28,66 5,50 Z" fill="#e9c987"/>
+  <!-- main wing (swept back delta) -->
+  <path d="M 82,64 L 210,70 L 252,96 L 67,80 Z" fill="#e9c987" opacity=".78"/>
+  <!-- horizontal stabilizer -->
+  <path d="M 226,42 L 260,28 L 270,44 Z" fill="#e9c987"/>
+  <!-- vertical stabilizer -->
+  <path d="M 244,26 L 260,8 L 272,28 Z" fill="#e9c987"/>
+  <!-- engine pod under wing -->
+  <path d="M 116,70 L 186,74 C 196,74 203,77 203,81 C 203,85 196,87 186,87 L 116,83 C 106,83 100,80 100,76 C 100,72 106,70 116,70 Z" fill="#e9c987" opacity=".82"/>
+  <!-- cockpit window strip -->
+  <path d="M 18,44 C 20,36 30,32 42,32 L 70,32 L 70,40 L 42,40 C 34,40 26,44 22,48 Z" fill="#0b0f20" opacity=".35"/>
+</svg>

--- a/assets/img/objects/balloon.svg
+++ b/assets/img/objects/balloon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 175">
+  <!-- balloon envelope -->
+  <ellipse cx="55" cy="74" rx="47" ry="60" fill="#e9c987" opacity=".88"/>
+  <!-- panel seams -->
+  <path d="M55,14 Q80,44 80,74 Q80,104 55,134" fill="none" stroke="#0b0f20" stroke-width="2.2" opacity=".22"/>
+  <path d="M55,14 Q30,44 30,74 Q30,104 55,134" fill="none" stroke="#0b0f20" stroke-width="2.2" opacity=".22"/>
+  <line x1="55" y1="14" x2="55" y2="134" stroke="#0b0f20" stroke-width="2.2" opacity=".12"/>
+  <!-- ropes -->
+  <line x1="20" y1="126" x2="35" y2="152" stroke="#e9c987" stroke-width="1.5"/>
+  <line x1="90" y1="126" x2="75" y2="152" stroke="#e9c987" stroke-width="1.5"/>
+  <!-- basket -->
+  <rect x="30" y="150" width="50" height="22" rx="3" fill="#e9c987"/>
+</svg>

--- a/assets/img/objects/eagle.svg
+++ b/assets/img/objects/eagle.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120">
+  <!-- left wing (curves up from body, feathered wingtip) -->
+  <path d="M 106,62 C 84,54 52,42 22,24 C 14,20 6,24 9,30 L 30,52 C 52,64 78,68 102,72 Z" fill="#e9c987"/>
+  <!-- right wing (mirror) -->
+  <path d="M 134,62 C 156,54 188,42 218,24 C 226,20 234,24 231,30 L 210,52 C 188,64 162,68 138,72 Z" fill="#e9c987"/>
+  <!-- body -->
+  <ellipse cx="120" cy="70" rx="20" ry="25" fill="#e9c987"/>
+  <!-- head -->
+  <circle cx="120" cy="44" r="14" fill="#e9c987"/>
+  <!-- beak (hooked) -->
+  <path d="M 120,52 L 132,58 L 120,64 Z" fill="#0b0f20" opacity=".5"/>
+  <!-- tail feathers -->
+  <path d="M 106,93 C 111,101 116,108 120,110 C 124,108 129,101 134,93 L 128,96 L 120,100 L 112,96 Z" fill="#e9c987" opacity=".85"/>
+  <!-- wing feather detail lines -->
+  <line x1="50" y1="48" x2="70" y2="62" stroke="#0b0f20" stroke-width="1" opacity=".18"/>
+  <line x1="80" y1="42" x2="96" y2="60" stroke="#0b0f20" stroke-width="1" opacity=".18"/>
+  <line x1="160" y1="42" x2="144" y2="60" stroke="#0b0f20" stroke-width="1" opacity=".18"/>
+  <line x1="190" y1="48" x2="170" y2="62" stroke="#0b0f20" stroke-width="1" opacity=".18"/>
+</svg>

--- a/assets/img/objects/helicopter.svg
+++ b/assets/img/objects/helicopter.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 270 118">
+  <!-- main rotor blades -->
+  <rect x="18" y="16" width="194" height="5" rx="2.5" fill="#e9c987"/>
+  <!-- rotor hub -->
+  <circle cx="118" cy="18" r="7" fill="#e9c987"/>
+  <!-- fuselage body -->
+  <path d="M 52,52 C 46,36 56,22 74,20 L 164,20 C 180,20 190,32 190,48 L 190,84 C 190,96 180,100 164,100 L 74,100 C 56,100 46,90 50,74 Z" fill="#e9c987"/>
+  <!-- tail boom -->
+  <path d="M 190,60 L 254,50 L 258,54 L 258,66 L 254,70 L 190,80 Z" fill="#e9c987" opacity=".84"/>
+  <!-- tail rotor disc -->
+  <ellipse cx="257" cy="50" rx="3" ry="15" fill="#e9c987" opacity=".9"/>
+  <!-- landing skids -->
+  <line x1="72" y1="100" x2="72" y2="112" stroke="#e9c987" stroke-width="2.5"/>
+  <line x1="158" y1="100" x2="158" y2="112" stroke="#e9c987" stroke-width="2.5"/>
+  <line x1="50" y1="112" x2="102" y2="112" stroke="#e9c987" stroke-width="2.5"/>
+  <line x1="132" y1="112" x2="184" y2="112" stroke="#e9c987" stroke-width="2.5"/>
+  <!-- cockpit window -->
+  <path d="M 58,52 C 56,40 63,30 76,28 L 128,28 C 140,28 148,36 148,48 L 148,60 C 140,64 64,64 60,60 Z" fill="#0b0f20" opacity=".42"/>
+</svg>

--- a/assets/img/objects/satellite.svg
+++ b/assets/img/objects/satellite.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 90">
+  <!-- main body -->
+  <rect x="78" y="32" width="44" height="26" rx="3" fill="#e9c987"/>
+  <!-- left solar panel -->
+  <rect x="6" y="38" width="64" height="14" rx="2" fill="#e9c987" opacity=".72"/>
+  <!-- right solar panel -->
+  <rect x="130" y="38" width="64" height="14" rx="2" fill="#e9c987" opacity=".72"/>
+  <!-- panel cell dividers left -->
+  <line x1="26" y1="38" x2="26" y2="52" stroke="#0b0f20" stroke-width="1.2"/>
+  <line x1="46" y1="38" x2="46" y2="52" stroke="#0b0f20" stroke-width="1.2"/>
+  <!-- panel cell dividers right -->
+  <line x1="150" y1="38" x2="150" y2="52" stroke="#0b0f20" stroke-width="1.2"/>
+  <line x1="170" y1="38" x2="170" y2="52" stroke="#0b0f20" stroke-width="1.2"/>
+  <!-- antenna mast -->
+  <line x1="100" y1="32" x2="100" y2="16" stroke="#e9c987" stroke-width="1.5"/>
+  <!-- antenna dish -->
+  <circle cx="100" cy="11" r="6" fill="#e9c987"/>
+  <!-- connection struts -->
+  <rect x="70" y="42" width="8" height="4" rx="1" fill="#e9c987"/>
+  <rect x="122" y="42" width="8" height="4" rx="1" fill="#e9c987"/>
+</svg>

--- a/assets/img/objects/sr71.svg
+++ b/assets/img/objects/sr71.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 310 90">
+  <!-- fuselage / chined body — very long needle nose -->
+  <path d="M 4,45 C 42,32 78,26 114,24 L 258,24 C 272,24 284,32 290,45 C 284,58 272,66 258,66 L 114,66 C 78,64 42,58 4,45 Z" fill="#e9c987"/>
+  <!-- delta wing (swept-back, seen from side as rear lower area) -->
+  <path d="M 86,58 L 264,64 L 276,82 L 70,72 Z" fill="#e9c987" opacity=".78"/>
+  <!-- vertical stabilizer -->
+  <path d="M 258,24 L 275,5 L 284,26 Z" fill="#e9c987"/>
+  <!-- engine nacelle -->
+  <path d="M 114,64 L 200,68 C 210,68 216,71 216,75 C 216,79 210,81 200,81 L 114,77 C 104,77 98,74 98,70 C 98,66 104,64 114,64 Z" fill="#e9c987" opacity=".82"/>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -789,4 +789,87 @@
       py = clamp(py, MARGIN, innerHeight - MARGIN);
     }, { passive: true });
   })();
+
+  /* ---- Experience entry modals ---- */
+  (function () {
+    const timeline = document.querySelector(".timeline");
+    const modal = document.getElementById("entryModal");
+    if (!timeline || !modal) return;
+
+    const panel = modal.querySelector(".entry-modal__panel");
+    const closeBtn = document.getElementById("modalClose");
+    const modalLayer = document.getElementById("modalLayer");
+    const modalOrg = document.getElementById("modalOrg");
+    const modalRole = document.getElementById("modalRole");
+    const modalDate = document.getElementById("modalDate");
+    const modalContent = document.getElementById("modalContent");
+
+    let focusBefore = null;
+
+    function openModal(entry) {
+      const layer = entry.getAttribute("data-layer") || "";
+      const alt = entry.getAttribute("data-alt") || "";
+      const org = entry.querySelector(".entry__org");
+      const role = entry.querySelector(".entry__role");
+      const date = entry.querySelector(".entry__date");
+      const detail = entry.querySelector(".entry__detail");
+
+      if (modalLayer) modalLayer.textContent = layer + (alt ? " · " + alt : "");
+      if (modalOrg && org) modalOrg.textContent = org.textContent;
+      if (modalRole && role) modalRole.textContent = role.textContent;
+      if (modalDate && date) modalDate.textContent = date.textContent;
+      if (modalContent && detail) modalContent.innerHTML = detail.innerHTML;
+      if (panel) panel.scrollTop = 0;
+
+      focusBefore = document.activeElement;
+      modal.hidden = false;
+      modal.removeAttribute("aria-hidden");
+      document.body.style.overflow = "hidden";
+      requestAnimationFrame(() => {
+        modal.classList.add("in");
+        if (closeBtn) closeBtn.focus();
+      });
+    }
+
+    function closeModal() {
+      modal.classList.remove("in");
+      modal.setAttribute("aria-hidden", "true");
+      document.body.style.overflow = "";
+      const done = () => {
+        modal.hidden = true;
+        if (focusBefore) focusBefore.focus();
+      };
+      modal.addEventListener("transitionend", done, { once: true });
+    }
+
+    timeline.addEventListener("click", (e) => {
+      if (document.documentElement.classList.contains("flying")) return;
+      const card = e.target.closest(".entry__card");
+      if (!card) return;
+      const entry = card.closest(".entry");
+      if (entry) openModal(entry);
+    });
+
+    timeline.addEventListener("keydown", (e) => {
+      if (document.documentElement.classList.contains("flying")) return;
+      if (e.key === "Enter" || e.key === " ") {
+        const card = e.target.closest(".entry__card");
+        if (card) {
+          e.preventDefault();
+          const entry = card.closest(".entry");
+          if (entry) openModal(entry);
+        }
+      }
+    });
+
+    if (closeBtn) closeBtn.addEventListener("click", closeModal);
+
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) closeModal();
+    });
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !modal.hidden) closeModal();
+    });
+  })();
 })();

--- a/index.html
+++ b/index.html
@@ -117,6 +117,20 @@
   </div>
 </div>
 
+<!-- ============ EXPERIENCE DETAIL MODAL ============ -->
+<div class="entry-modal" id="entryModal" hidden aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalOrg">
+  <div class="entry-modal__panel">
+    <button type="button" class="entry-modal__close" id="modalClose" aria-label="Close">✕</button>
+    <header class="entry-modal__header">
+      <span class="entry-modal__layer" id="modalLayer"></span>
+      <h2 class="entry-modal__org" id="modalOrg"></h2>
+      <p class="entry-modal__role" id="modalRole"></p>
+      <time class="entry-modal__date" id="modalDate"></time>
+    </header>
+    <div class="entry-modal__body" id="modalContent"></div>
+  </div>
+</div>
+
 <main>
 
 <!-- ============ HERO ============ -->
@@ -188,13 +202,20 @@
         <img src="assets/img/thermosphere.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
-      <div class="entry__meta">
-        <span class="entry__no">01</span>
-        <time class="entry__date">Jul 2025 – Jun 2026</time>
-      </div>
-      <div class="entry__main">
+      <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for WarTable by Freestyle Consulting">
+        <div class="entry__card-top">
+          <span class="entry__layer-badge">Thermosphere · 80–700 km</span>
+          <span class="entry__no" aria-hidden="true">01</span>
+        </div>
         <h3 class="entry__org">WarTable by Freestyle Consulting</h3>
         <p class="entry__role">Software Engineer (Full-Stack &amp; DevOps) — Contract</p>
+        <p class="entry__summary">Took an AI agent platform from zero to production on GCP</p>
+        <div class="entry__card-foot">
+          <time class="entry__date">Jul 2025 – Jun 2026</time>
+          <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
+        </div>
+      </button>
+      <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>Took WarTable from nothing to a production application built around Athena, an AI agent users chat with on the web and on mobile. Athena can connect to roughly 3,000 apps through Pipedream Connect, and I built a filtering layer that lets users turn individual MCP server tools on or off, plus support for dynamic client MCP servers so users can plug in their own.</p>
           <p>I built the knowledge base system on ChromaDB: users connect and browse their Drive apps and sync files into knowledge bases, where document contents are extracted, chunked, and embedded (or summarized), and both Athena and the WBHI draw on those alongside the connected apps. Syncing is automatic — users can watch a folder, get a WarTable notification when new files land, and choose to sync all, some, or none, with an ignore feature for files they want skipped. Memory is handled with mem0, scoped at both the user and workspace level, and real-time notifications and AI response streaming run over WebSockets.</p>
@@ -212,13 +233,20 @@
         <img src="assets/img/mesosphere.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
-      <div class="entry__meta">
-        <span class="entry__no">02</span>
-        <time class="entry__date">Dec 2024 – Dec 2025</time>
-      </div>
-      <div class="entry__main">
+      <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for HYVV">
+        <div class="entry__card-top">
+          <span class="entry__layer-badge">Mesosphere · 50–85 km</span>
+          <span class="entry__no" aria-hidden="true">02</span>
+        </div>
         <h3 class="entry__org">HYVV</h3>
         <p class="entry__role">Software Engineer (Full-Stack &amp; DevOps) — Contract</p>
+        <p class="entry__summary">Built early AI features and ran the entire dev pipeline solo</p>
+        <div class="entry__card-foot">
+          <time class="entry__date">Dec 2024 – Dec 2025</time>
+          <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
+        </div>
+      </button>
+      <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>Built early AI features for the platform on the OpenAI API. One was a conversational agent backed by a clipboard-style questionnaire and talking points that extracted context from users so the platform could plan and carry out tasks for their business. Another let users generate products and features — complete with images — from a single prompt. This was early 2025, when AI apps were still mostly structured output behind a button, before heavy tool use or MCP.</p>
           <p>After the other engineers separated from the company, I took responsibility for the entire development pipeline — running everything on GCP, handling CI/CD through GitHub Actions, and managing the database.</p>
@@ -234,13 +262,20 @@
         <img src="assets/img/stratosphere.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
-      <div class="entry__meta">
-        <span class="entry__no">03</span>
-        <time class="entry__date">Jan 2025 – Aug 2025</time>
-      </div>
-      <div class="entry__main">
+      <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for Project Sustain, Colorado State University">
+        <div class="entry__card-top">
+          <span class="entry__layer-badge">Stratosphere · 12–50 km</span>
+          <span class="entry__no" aria-hidden="true">03</span>
+        </div>
         <h3 class="entry__org">Project Sustain, Colorado State University</h3>
         <p class="entry__role">Software Engineer &amp; Research Assistant</p>
+        <p class="entry__summary">Built academic tooling, an AI-powered citation checker, and contributed to drone-swarm research</p>
+        <div class="entry__card-foot">
+          <time class="entry__date">Jan 2025 – Aug 2025</time>
+          <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
+        </div>
+      </button>
+      <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>My first feature on RamDesk — the CSU computer-science department's platform — was a statistics suite: Python backend endpoints feeding frontend graphs and plots that surface student grades, submission counts, submission timing, and similar metrics.</p>
           <p>I then extended a tool built to detect AI-written student papers by adding a system that flags suspicious references in a paper's bibliography. It uses OpenAI structured output to extract citation details from any format (MLA and the rest), then cross-checks that metadata against the open web. The checker tries the cheapest signal first — a DOI if there is one, then a URL, and finally an author/title/year lookup that actually has to search — and runs across DuckDuckGo, Bing, and Google so a rate limit on one engine falls through to the others. It drives Selenium with Firefox inside a container; getting past bot detection is hard, so the system deliberately errs toward false negatives, only flagging a reference when nothing checks out.</p>
@@ -257,13 +292,20 @@
         <img src="assets/img/peak.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
-      <div class="entry__meta">
-        <span class="entry__no">04</span>
-        <time class="entry__date">Aug 2023 – Dec 2025</time>
-      </div>
-      <div class="entry__main">
+      <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for Colorado State University Teaching Assistant">
+        <div class="entry__card-top">
+          <span class="entry__layer-badge">Cloud Line · 5,000 m</span>
+          <span class="entry__no" aria-hidden="true">04</span>
+        </div>
         <h3 class="entry__org">Colorado State University</h3>
         <p class="entry__role">Undergraduate Teaching Assistant</p>
+        <p class="entry__summary">Mentored 200+ students per semester in Python, Java, and software development</p>
+        <div class="entry__card-foot">
+          <time class="entry__date">Aug 2023 – Dec 2025</time>
+          <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
+        </div>
+      </button>
+      <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>I taught Python (Fall 2023), Java (Spring 2024), and Software Development (Fall 2024 onward). I mentored more than 200 students each semester in coding, debugging, and software best practices, and I developed labs and course materials.</p>
         </div>
@@ -278,13 +320,20 @@
         <img src="assets/img/mountains.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
-      <div class="entry__meta">
-        <span class="entry__no">05</span>
-        <time class="entry__date">Jan 2024 – Dec 2025</time>
-      </div>
-      <div class="entry__main">
+      <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for CSU Robotics Lab">
+        <div class="entry__card-top">
+          <span class="entry__layer-badge">Alpine · 4,000 m</span>
+          <span class="entry__no" aria-hidden="true">05</span>
+        </div>
         <h3 class="entry__org">CSU Robotics Lab</h3>
         <p class="entry__role">Robotics Research Volunteer</p>
+        <p class="entry__summary">Mapped a building with LIDAR and built an autonomous Halloween candy-delivery demo on real hardware</p>
+        <div class="entry__card-foot">
+          <time class="entry__date">Jan 2024 – Dec 2025</time>
+          <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
+        </div>
+      </button>
+      <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>A year of unpaid, volunteer robotics research at CSU — I took it for the chance to work with expensive hardware. A friend from the video game dev club I'd done game jams with got me into the lab before he transferred schools. The lab had an old ROS-based Fetch robot and a newer ROS2 robot I worked with virtually. My first task was to master the Fetch in simulation: I spent about a month buried in the ROS and Fetch docs, running the demos, and learning the fiddly details — placing AR tags in Gazebo, catching when configs are in meters versus millimeters, lighting, and driving and monitoring the robot through RViz.</p>
           <p>Next I checked whether the physical robot still worked, now that the student who had been running it was gone, so I spent several nights verifying that everything I'd done in simulation held up on real hardware, writing scripts to reset the robot to known positions while testing routines and keeping it well clear of obstacles. Late one night, with the building empty, I mapped the lobby of the CS building using ROS's Fetch navigation and mapping nodes, building an occupancy map from the LIDAR and laser scans and marking out no-go zones.</p>
@@ -301,13 +350,20 @@
         <img src="assets/img/canyon.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
-      <div class="entry__meta">
-        <span class="entry__no">06</span>
-        <time class="entry__date">Oct 2018 – Oct 2022</time>
-      </div>
-      <div class="entry__main">
+      <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for US Marine Corps">
+        <div class="entry__card-top">
+          <span class="entry__layer-badge">High Desert · 1,500 m</span>
+          <span class="entry__no" aria-hidden="true">06</span>
+        </div>
         <h3 class="entry__org">US Marine Corps</h3>
         <p class="entry__role">Refrigeration Technician · Utilities Operations SNCO · Utilities Quality Control SNCO</p>
+        <p class="entry__summary">Ran power operations at the Corps' largest field exercise and managed a 50+ generator fleet</p>
+        <div class="entry__card-foot">
+          <time class="entry__date">Oct 2018 – Oct 2022</time>
+          <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
+        </div>
+      </button>
+      <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>I served as a Meritorious Corporal in the 4th Marines, 3rd Marine Division. I started as a refrigeration technician — air conditioning and HVAC/R — reading schematics, troubleshooting from technical manuals, and repairing equipment, and my scope quickly grew beyond AC to electrical systems, diesel-engine generators, and water purification systems, along with the inventory and maintenance they required.</p>
           <p>I moved up to Quality Control NCO and effectively became the operator-maintenance manager for the section. Most equipment had tasks the operator was responsible for and others handled at a different echelon — scheduled or corrective — and the program was a mess when I arrived. I brought our entire generator fleet under control: more than fifty AMMPS sets ranging from 1.5kW to 30kW, powered by Cummins, Kubota, and Yanmar engines. I owned the scheduled maintenance while a counterpart handled corrective, tracking technician sheets, scheduling services, moving equipment, and ordering parts through a clunky maintenance system where every level of the chain of command had its own rules for how fields should be filled in and categorized. You would think it could scan a technical manual, match a manufacturer ID, and load the checklists and intervals automatically — it could not. Once it was sorted, it ran smoothly. I was trusted enough with the maintenance-management process that I was also put in charge of the company's combat engineer equipment — heavy demolition and construction gear — even though we had no combat engineers.</p>

--- a/index.html
+++ b/index.html
@@ -202,6 +202,10 @@
         <img src="assets/img/thermosphere.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
+      <div class="entry__scene">
+      <div class="entry__object" aria-hidden="true">
+        <img src="assets/img/objects/satellite.svg" alt="" />
+      </div>
       <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for WarTable by Freestyle Consulting">
         <div class="entry__card-top">
           <span class="entry__layer-badge">Thermosphere · 80–700 km</span>
@@ -215,6 +219,7 @@
           <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
         </div>
       </button>
+      </div>
       <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>Took WarTable from nothing to a production application built around Athena, an AI agent users chat with on the web and on mobile. Athena can connect to roughly 3,000 apps through Pipedream Connect, and I built a filtering layer that lets users turn individual MCP server tools on or off, plus support for dynamic client MCP servers so users can plug in their own.</p>
@@ -233,6 +238,10 @@
         <img src="assets/img/mesosphere.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
+      <div class="entry__scene">
+      <div class="entry__object" aria-hidden="true">
+        <img src="assets/img/objects/balloon.svg" alt="" />
+      </div>
       <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for HYVV">
         <div class="entry__card-top">
           <span class="entry__layer-badge">Mesosphere · 50–85 km</span>
@@ -246,6 +255,7 @@
           <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
         </div>
       </button>
+      </div>
       <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>Built early AI features for the platform on the OpenAI API. One was a conversational agent backed by a clipboard-style questionnaire and talking points that extracted context from users so the platform could plan and carry out tasks for their business. Another let users generate products and features — complete with images — from a single prompt. This was early 2025, when AI apps were still mostly structured output behind a button, before heavy tool use or MCP.</p>
@@ -262,6 +272,10 @@
         <img src="assets/img/stratosphere.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
+      <div class="entry__scene">
+      <div class="entry__object" aria-hidden="true">
+        <img src="assets/img/objects/sr71.svg" alt="" />
+      </div>
       <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for Project Sustain, Colorado State University">
         <div class="entry__card-top">
           <span class="entry__layer-badge">Stratosphere · 12–50 km</span>
@@ -275,6 +289,7 @@
           <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
         </div>
       </button>
+      </div>
       <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>My first feature on RamDesk — the CSU computer-science department's platform — was a statistics suite: Python backend endpoints feeding frontend graphs and plots that surface student grades, submission counts, submission timing, and similar metrics.</p>
@@ -292,6 +307,10 @@
         <img src="assets/img/peak.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
+      <div class="entry__scene">
+      <div class="entry__object" aria-hidden="true">
+        <img src="assets/img/objects/airliner.svg" alt="" />
+      </div>
       <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for Colorado State University Teaching Assistant">
         <div class="entry__card-top">
           <span class="entry__layer-badge">Cloud Line · 5,000 m</span>
@@ -305,6 +324,7 @@
           <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
         </div>
       </button>
+      </div>
       <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>I taught Python (Fall 2023), Java (Spring 2024), and Software Development (Fall 2024 onward). I mentored more than 200 students each semester in coding, debugging, and software best practices, and I developed labs and course materials.</p>
@@ -320,6 +340,10 @@
         <img src="assets/img/mountains.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
+      <div class="entry__scene">
+      <div class="entry__object" aria-hidden="true">
+        <img src="assets/img/objects/eagle.svg" alt="" />
+      </div>
       <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for CSU Robotics Lab">
         <div class="entry__card-top">
           <span class="entry__layer-badge">Alpine · 4,000 m</span>
@@ -333,6 +357,7 @@
           <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
         </div>
       </button>
+      </div>
       <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>A year of unpaid, volunteer robotics research at CSU — I took it for the chance to work with expensive hardware. A friend from the video game dev club I'd done game jams with got me into the lab before he transferred schools. The lab had an old ROS-based Fetch robot and a newer ROS2 robot I worked with virtually. My first task was to master the Fetch in simulation: I spent about a month buried in the ROS and Fetch docs, running the demos, and learning the fiddly details — placing AR tags in Gazebo, catching when configs are in meters versus millimeters, lighting, and driving and monitoring the robot through RViz.</p>
@@ -350,6 +375,10 @@
         <img src="assets/img/canyon.jpg" alt="" data-parallax="0.05" />
         <div class="entry__veil"></div>
       </div>
+      <div class="entry__scene">
+      <div class="entry__object" aria-hidden="true">
+        <img src="assets/img/objects/helicopter.svg" alt="" />
+      </div>
       <button class="entry__card" aria-haspopup="dialog" aria-label="Open details for US Marine Corps">
         <div class="entry__card-top">
           <span class="entry__layer-badge">High Desert · 1,500 m</span>
@@ -363,6 +392,7 @@
           <span class="entry__open-hint" aria-hidden="true">Details ↗</span>
         </div>
       </button>
+      </div>
       <div class="entry__detail" hidden>
         <div class="entry__text">
           <p>I served as a Meritorious Corporal in the 4th Marines, 3rd Marine Division. I started as a refrigeration technician — air conditioning and HVAC/R — reading schematics, troubleshooting from technical manuals, and repairing equipment, and my scope quickly grew beyond AC to electrical systems, diesel-engine generators, and water purification systems, along with the inventory and maintenance they required.</p>


### PR DESCRIPTION
## Summary

- Each experience entry is now a compact frosted-glass card floating over the full-bleed atmospheric background image — the scenic photography gets to breathe instead of being buried under text
- Each card shows the layer badge (e.g. *Thermosphere · 80–700 km*), entry number, company, role, and a single-sentence summary of what you did there
- Clicking a card opens a modal with the full description word-for-word (no changes to any existing copy) plus the tech chips and a close button; Escape and backdrop-click also close it
- The modal matches the site's existing aesthetic (same dark gradient panel, blur backdrop, gold/cyan accents) and scrolls on smaller screens
- Flight mode is respected — clicking entries does nothing while the game is active

## Test plan

- [ ] Scroll through the experience section — background images visible behind each card
- [ ] Hover over a card — border brightens, card lifts slightly, "Details ↗" hint goes full opacity
- [ ] Click each card — modal opens with correct org, role, date, full description, and chips
- [ ] Verify all six descriptions are word-for-word identical to the original HTML
- [ ] Close via ✕ button, Escape key, and backdrop click
- [ ] Test on mobile — cards go full-width, footer stacks vertically
- [ ] Start flight mode and confirm clicking entries does not open modals

https://claude.ai/code/session_01Vu5ym4JcpWhPvTJj6iccfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu5ym4JcpWhPvTJj6iccfA)_