### PR TITLE
Fix ocean scene disappearing at bottom of page on mobile

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1129,7 +1129,11 @@
       const dt = Math.min(0.05, (now - lastMs) / 1000); lastMs = now;
       const m = metrics();
       const fTop = m.sy / m.sh;                 // true world fraction (top of viewport)
-      const target = m.sy / m.docH;
+      // clamp to [0,1]: mobile browsers can momentarily report scrollY past
+      // docH while the address bar collapses/expands near the bottom of the
+      // page, and band()'s zero-width fOut at hi=1 turns any overshoot into
+      // a divide-by-zero that blanks the ocean layer out entirely
+      const target = clamp01(m.sy / m.docH);
       p += (target - p) * (reduceMotion ? 1 : 0.12);
       mouse.x += (mouse.tx - mouse.x) * 0.06;
       mouse.y += (mouse.ty - mouse.y) * 0.06;
@@ -1507,7 +1511,7 @@
     if (reduceMotion) window.addEventListener("scroll", () => requestAnimationFrame(draw), { passive: true });
 
     resize();
-    p = (function () { const m = metrics(); return m.sy / m.docH; })();
+    p = (function () { const m = metrics(); return clamp01(m.sy / m.docH); })();
     requestAnimationFrame(draw);
   })();
 })();


### PR DESCRIPTION
## Summary
- Fixes the ocean/underwater layer of the procedural descent scene (`assets/js/main.js`) vanishing when scrolled all the way to the bottom of the page on mobile, then reappearing on the slightest scroll up.
- Root cause: the underwater fade uses `band(p, 0.86, 1.0, 0.03, 0.0)` — a zero-width fade-out at the `hi = 1.0` edge. On mobile, scrolling to the very bottom collapses the browser's address bar, which grows `innerHeight` and shrinks the scrollable range (`docH = scrollHeight - innerHeight`) while `scrollY` is still at its old max. That pushes the scroll fraction (`scrollY / docH`) slightly above `1`, which lands in `band()`'s "past hi" branch and divides by `fOut = 0`, producing `-Infinity`/`NaN` and blanking the ocean's opacity. The same applies to the sea-floor fade band further down.
- Fix: clamp the scroll fraction to `[0, 1]` at the source (both where it's computed each frame and on initial load), so it can never overshoot the domain the fade bands expect.

## Test plan
- [ ] On a mobile device/emulator, scroll all the way to the bottom of the page (past where the address bar collapses) and confirm the ocean/underwater scene stays visible.
- [ ] Confirm scrolling back up still behaves smoothly with no visual jump.
- [ ] Spot-check the rest of the descent scene (space → mountains → ocean) for any regressions from the clamp.

https://claude.ai/code/session_017ogSWxPbPEmfcZfr8EAxt6


---
_Generated by [Claude Code](https://claude.ai/code/session_017ogSWxPbPEmfcZfr8EAxt6)_