### PR TITLE
Redesign experience & skills into scannable, colorful UI

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -632,6 +632,48 @@ main, .nav, .foot { position: relative; z-index: 2; }
 .entry__text p { color: var(--text-dim); margin-bottom: 1.1rem; font-size: 1.01rem; }
 .entry__text p:last-child { margin-bottom: 0; }
 
+/* ---------- impact tiles ---------- */
+.tiles {
+  list-style: none; display: grid; gap: .75rem; margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+.tile {
+  display: flex; flex-direction: column; gap: .35rem;
+  padding: 1rem 1.05rem; border-radius: 10px;
+  border: 1px solid var(--line);
+  background: rgba(160,168,220,0.03);
+  transition: border-color .25s var(--ease), background .25s var(--ease),
+              box-shadow .25s var(--ease), transform .25s var(--ease);
+}
+.tile__cat {
+  font-family: var(--f-mono); font-size: .64rem; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--cyan);
+}
+.tile__key {
+  font-family: var(--f-display); font-weight: 500; line-height: 1.02;
+  font-size: clamp(1.45rem, 2.5vw, 1.9rem);
+  color: var(--gold);
+  text-shadow: 0 0 18px rgba(233,201,135,0.35);
+}
+.tile__desc {
+  font-size: .84rem; line-height: 1.4; color: var(--text-dim);
+  margin-top: .1rem;
+}
+.tile__impact {
+  display: flex; gap: .45rem; align-items: baseline;
+  font-size: .8rem; line-height: 1.4; color: var(--text);
+  margin-top: auto; padding-top: .55rem;
+}
+.tile__impact::before {
+  content: "\2192"; color: var(--cyan); flex: none; font-weight: 600;
+}
+.tile:hover {
+  transform: translateY(-3px);
+  border-color: rgba(233,201,135,0.45);
+  background: rgba(233,201,135,0.05);
+  box-shadow: 0 0 22px rgba(233,201,135,0.15);
+}
+
 @media (max-width: 820px) {
   .entry { grid-template-columns: 1fr; gap: .9rem; padding-left: 0; }
   .entry::before { display: none; }
@@ -645,13 +687,30 @@ main, .nav, .foot { position: relative; z-index: 2; }
   margin-top: 1.6rem;
 }
 .chips li {
+  --c: var(--gold);
   font-family: var(--f-mono); font-size: .72rem; letter-spacing: .02em;
-  color: var(--text-dim);
-  border: 1px solid var(--line); border-radius: 100px;
-  padding: .32rem .8rem; background: rgba(160,168,220,0.03);
-  transition: border-color .25s, color .25s, background .25s;
+  color: var(--c);
+  border: 1px solid color-mix(in srgb, var(--c) 32%, transparent);
+  border-radius: 100px;
+  padding: .32rem .8rem;
+  background: color-mix(in srgb, var(--c) 8%, transparent);
+  transition: border-color .25s var(--ease), box-shadow .25s var(--ease),
+              background .25s var(--ease), transform .25s var(--ease);
 }
-.chips li:hover { border-color: rgba(233,201,135,0.4); color: var(--gold); background: rgba(233,201,135,0.06); }
+/* cycle neon hues across the tech chips */
+.chips li:nth-child(7n+1) { --c: #e9c987; }
+.chips li:nth-child(7n+2) { --c: #7fd6e8; }
+.chips li:nth-child(7n+3) { --c: #e08aa8; }
+.chips li:nth-child(7n+4) { --c: #8fe0a8; }
+.chips li:nth-child(7n+5) { --c: #b79cff; }
+.chips li:nth-child(7n+6) { --c: #ffb27f; }
+.chips li:nth-child(7n+7) { --c: #7fb3e8; }
+.chips li:hover {
+  border-color: color-mix(in srgb, var(--c) 60%, transparent);
+  background: color-mix(in srgb, var(--c) 18%, transparent);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--c) 35%, transparent);
+  transform: translateY(-2px);
+}
 
 /* ============================================================
    EDUCATION
@@ -725,19 +784,51 @@ main, .nav, .foot { position: relative; z-index: 2; }
    ============================================================ */
 .skills-grid { border-top: 1px solid var(--line); }
 .skillrow {
+  --c: var(--gold);   /* per-category accent, set below */
   display: grid; grid-template-columns: 280px 1fr;
   gap: 1.5rem; align-items: baseline;
   padding: 1.25rem 0; border-bottom: 1px solid var(--line-soft);
   transition: background .3s;
 }
+/* color-coded categories — each group gets its own neon hue */
+.skillrow:nth-child(1)  { --c: #e9c987; }
+.skillrow:nth-child(2)  { --c: #7fd6e8; }
+.skillrow:nth-child(3)  { --c: #e08aa8; }
+.skillrow:nth-child(4)  { --c: #8fe0a8; }
+.skillrow:nth-child(5)  { --c: #b79cff; }
+.skillrow:nth-child(6)  { --c: #ffb27f; }
+.skillrow:nth-child(7)  { --c: #7fb3e8; }
+.skillrow:nth-child(8)  { --c: #f4e08a; }
+.skillrow:nth-child(9)  { --c: #9ce8c8; }
+.skillrow:nth-child(10) { --c: #e89ce0; }
+.skillrow:nth-child(11) { --c: #cbd0f0; }
 .skillrow:hover { background: rgba(160,168,220,0.025); }
 .skillrow dt {
   font-family: var(--f-display); font-style: italic; font-weight: 400;
-  font-size: 1.45rem; color: var(--gold-soft);
+  font-size: 1.45rem; color: var(--c);
+  text-shadow: 0 0 16px color-mix(in srgb, var(--c) 40%, transparent);
 }
-.skillrow dd { font-size: 1.02rem; color: var(--text-dim); letter-spacing: .01em; }
+.skillrow dd {
+  display: flex; flex-wrap: wrap; gap: .45rem;
+  font-size: 1.02rem; color: var(--text-dim); letter-spacing: .01em;
+}
+.skillrow dd span {
+  font-family: var(--f-mono); font-size: .74rem; letter-spacing: .02em;
+  color: var(--c);
+  border: 1px solid color-mix(in srgb, var(--c) 32%, transparent);
+  background: color-mix(in srgb, var(--c) 8%, transparent);
+  border-radius: 100px; padding: .32rem .78rem;
+  transition: background .25s var(--ease), box-shadow .25s var(--ease),
+              border-color .25s var(--ease), transform .25s var(--ease);
+}
+.skillrow dd span:hover {
+  background: color-mix(in srgb, var(--c) 18%, transparent);
+  border-color: color-mix(in srgb, var(--c) 60%, transparent);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--c) 35%, transparent);
+  transform: translateY(-2px);
+}
 @media (max-width: 720px) {
-  .skillrow { grid-template-columns: 1fr; gap: .4rem; }
+  .skillrow { grid-template-columns: 1fr; gap: .5rem; }
   .skillrow dt { font-size: 1.3rem; }
 }
 
@@ -767,8 +858,49 @@ main, .nav, .foot { position: relative; z-index: 2; }
   color: var(--gold-soft); font-size: .7rem;
 }
 .record-list--desc > li { display: flex; flex-direction: column; gap: .35rem; }
-.record__name { font-family: var(--f-display); font-size: 1.25rem; font-weight: 500; color: var(--star); line-height: 1.2; }
+.record__name { font-family: var(--f-display); font-size: 1.25rem; font-weight: 500; color: var(--star); line-height: 1.2; transition: color .3s var(--ease); }
 .record__desc { font-size: .9rem; color: var(--text-dim); line-height: 1.55; }
+
+/* ---------- service record flourishes ---------- */
+/* ribbon-colored top bar on each panel */
+.medal-group { position: relative; overflow: hidden; }
+.medal-group::before {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: linear-gradient(90deg, var(--gold), var(--rose) 55%, var(--cyan));
+  opacity: .85;
+}
+/* gold accent segment under the group title */
+.medal-group__title { position: relative; }
+.medal-group__title::after {
+  content: ""; position: absolute; left: 0; bottom: -1px; height: 2px; width: 2.6rem;
+  background: linear-gradient(90deg, var(--gold), transparent);
+}
+/* awards get a little service-ribbon bar instead of a plain star */
+.record-list--desc > li { padding-left: 2.4rem; min-height: 1.7rem; }
+.record-list--desc > li::before {
+  content: ""; left: 0; top: .12rem;
+  width: 1rem; height: 1.55rem; border-radius: 3px;
+  background:
+    linear-gradient(90deg, transparent 42%, rgba(255,255,255,0.28) 50%, transparent 58%),
+    linear-gradient(180deg, var(--gold), var(--gold-soft));
+  box-shadow:
+    inset 0 0 0 1px rgba(0,0,0,0.25),
+    inset 0 2px 2px rgba(255,255,255,0.3),
+    0 1px 3px rgba(0,0,0,0.4);
+  transition: transform .3s var(--ease), box-shadow .3s var(--ease);
+}
+.record-list--desc > li:hover::before {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 0 0 1px rgba(0,0,0,0.25),
+    inset 0 2px 2px rgba(255,255,255,0.35),
+    0 0 14px rgba(233,201,135,0.55),
+    0 2px 5px rgba(0,0,0,0.4);
+}
+.record-list--desc > li:hover .record__name { color: #fff; }
+@media (prefers-reduced-motion: reduce) {
+  .record-list--desc > li:hover::before { transform: none; }
+}
 
 /* ============================================================
    CONTACT

--- a/index.html
+++ b/index.html
@@ -191,9 +191,34 @@
         <h3 class="entry__org">WarTable by Freestyle Consulting</h3>
         <p class="entry__role">Software Engineer (Full-Stack &amp; DevOps), Contract</p>
         <div class="entry__text">
-          <p>I built WarTable from nothing into a live, monetized product with real users. At its core is Athena, an AI agent users chat with that can act across roughly 3,000 connected apps, with fine-grained control over which tools it can use and support for users plugging in their own. I built the retrieval system on ChromaDB so the agent can draw on a user's synced documents, with memory that persists across conversations and real-time streaming over WebSockets.</p>
-          <p>I also built the multi-agent system behind the WarTable Business Health Index, where agents work across a user's data to score the health of their business and generate verified, prioritized tasks to improve it. On the infrastructure side I owned the full pipeline: billing and credits, multiple environments on GCP, and CI/CD to Cloud Run. It is a product I took end to end, from architecture to paying customers.</p>
+          <p>WarTable is an AI platform for small businesses. I took it from an empty repo to a live, monetized product with paying users, owning every layer myself.</p>
         </div>
+        <ul class="tiles" aria-label="Highlights">
+          <li class="tile">
+            <span class="tile__cat">Agent</span>
+            <span class="tile__key">Athena</span>
+            <span class="tile__desc">Chat agent that takes actions across ~3,000 connected apps, with fine-grained tool control.</span>
+            <span class="tile__impact">The core of the product and its main draw for users.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Knowledge</span>
+            <span class="tile__key">Retrieval + memory</span>
+            <span class="tile__desc">ChromaDB retrieval over each user's synced docs, with memory across conversations.</span>
+            <span class="tile__impact">Answers grounded in the user's own data.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Automation</span>
+            <span class="tile__key">Health Index</span>
+            <span class="tile__desc">Multi-agent system that scores a business and generates prioritized tasks.</span>
+            <span class="tile__impact">Turns scattered business data into a list of what to fix.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Infrastructure</span>
+            <span class="tile__key">Billing + infra</span>
+            <span class="tile__desc">Credits and billing, multiple GCP environments, and CI/CD to Cloud Run.</span>
+            <span class="tile__impact">Ran in production and took payments.</span>
+          </li>
+        </ul>
         <ul class="chips" aria-label="Technologies">
           <li>Next.js</li><li>Nest.js</li><li>Prisma + PostgreSQL</li><li>GCP</li><li>Firebase</li><li>OpenRouter</li><li>Pipedream</li><li>Vapi</li><li>ChromaDB</li><li>mem0</li><li>Stripe</li>
         </ul>
@@ -212,9 +237,28 @@
         <h3 class="entry__org">HYVV</h3>
         <p class="entry__role">Software Engineer (Full-Stack &amp; DevOps), Contract</p>
         <div class="entry__text">
-          <p>Built the platform's first AI features on the OpenAI API: a conversational agent that gathered context from users to plan and carry out work for their business, and a tool that generated products and features, images included, from a single prompt. This was early 2025, when most AI apps were still structured output behind a button, before heavy tool use or MCP.</p>
-          <p>When the other engineers left the company, I took over the entire development pipeline on my own, running everything on GCP and handling CI/CD and the database.</p>
+          <p>HYVV is a business platform. I built its first AI features, then took over the entire development pipeline when the rest of the team left.</p>
         </div>
+        <ul class="tiles" aria-label="Highlights">
+          <li class="tile">
+            <span class="tile__cat">AI</span>
+            <span class="tile__key">Work agent</span>
+            <span class="tile__desc">Conversational agent that gathered context about users' businesses.</span>
+            <span class="tile__impact">The platform's first AI feature.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Generation</span>
+            <span class="tile__key">Product generator</span>
+            <span class="tile__desc">Generated whole products and features, images included, from a single prompt.</span>
+            <span class="tile__impact">Users could draft offerings without building them by hand.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Ownership</span>
+            <span class="tile__key">Sole engineer</span>
+            <span class="tile__desc">When the team scaled down, I ran GCP, CI/CD, and the database alone.</span>
+            <span class="tile__impact">Kept the platform shipping with no one else on it.</span>
+          </li>
+        </ul>
         <ul class="chips" aria-label="Technologies">
           <li>OpenAI API</li><li>Structured Output</li><li>Next.js</li><li>Node.js</li><li>Express</li><li>Prisma + PostgreSQL</li><li>GCP</li><li>Stripe</li><li>GitHub Actions</li><li>CI/CD</li>
         </ul>
@@ -233,10 +277,34 @@
         <h3 class="entry__org">Project Sustain, Colorado State University</h3>
         <p class="entry__role">Software Engineer &amp; Research Assistant</p>
         <div class="entry__text">
-          <p>I built a statistics suite for RamDesk, the CSU computer science department's platform: Python endpoints feeding frontend graphs and plots of student grades, submission counts, submission timing, and similar metrics.</p>
-          <p>I also built a citation checker that flags suspicious references in a paper's bibliography. It verifies citations against the open web with some scraping and surfaces questionable ones for faculty to review, deliberately leaning toward false negatives so it only flags a reference when nothing checks out. The verification ran in Docker, dispatched across worker machines, which gave me solid hands-on Docker experience.</p>
-          <p>Beyond that, I worked constantly against the Canvas LMS API to build grading and inspection features and faster replacements for parts of the sluggish Canvas web interface, built admin views, produced tutorial videos and documentation, and contributed to HoneyComb, a UAV drone-swarm system for agricultural intelligence. I received the REI Undergraduate Research Stipend in Summer 2025.</p>
+          <p>Project Sustain is a research group in CSU's computer science department. I built data tooling and AI features across its platforms and earned the REI Undergraduate Research Stipend.</p>
         </div>
+        <ul class="tiles" aria-label="Highlights">
+          <li class="tile">
+            <span class="tile__cat">Analytics</span>
+            <span class="tile__key">Stats suite</span>
+            <span class="tile__desc">Python endpoints powering RamDesk graphs of grades, submissions, and timing.</span>
+            <span class="tile__impact">Gave faculty a real view into how their classes were doing.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Integrity</span>
+            <span class="tile__key">Citation checker</span>
+            <span class="tile__desc">Checks a paper's references against the open web, flagging one only when nothing checks out. Ran in Docker across worker machines.</span>
+            <span class="tile__impact">Cut manual bibliography review while keeping false alarms low.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Canvas LMS</span>
+            <span class="tile__key">Grading tools</span>
+            <span class="tile__desc">Grading and inspection features, admin views, and faster replacements for the slow Canvas UI.</span>
+            <span class="tile__impact">Less faculty time lost fighting the Canvas interface.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Robotics</span>
+            <span class="tile__key">HoneyComb</span>
+            <span class="tile__desc">Contributed to a UAV swarm system for agricultural intelligence.</span>
+            <span class="tile__impact">Hands-on work with multi-drone coordination.</span>
+          </li>
+        </ul>
         <ul class="chips" aria-label="Technologies">
           <li>Python</li><li>Flask</li><li>React</li><li>MongoDB</li><li>OpenAI API</li><li>Structured Output</li><li>Selenium</li><li>Docker</li><li>Canvas API</li><li>Web Scraping</li><li>Data Viz</li><li>UAV Systems</li>
         </ul>
@@ -255,8 +323,28 @@
         <h3 class="entry__org">Colorado State University</h3>
         <p class="entry__role">Undergraduate Teaching Assistant</p>
         <div class="entry__text">
-          <p>I taught Python (Fall 2023), Java (Spring 2024), and Software Development (Fall 2024 onward), mentoring more than 200 students each semester in coding, debugging, and software best practices. One semester, working with a new instructor, I wrote all of the programming assignments for the course myself, including the instructions, starter material, and full solutions, along with other labs and course materials.</p>
+          <p>Five semesters as a teaching assistant at CSU, in front of the classroom and behind the curriculum.</p>
         </div>
+        <ul class="tiles" aria-label="Highlights">
+          <li class="tile">
+            <span class="tile__cat">Teaching</span>
+            <span class="tile__key">Three courses</span>
+            <span class="tile__desc">Python, Java, and Software Development.</span>
+            <span class="tile__impact">Covered the core of the intro CS sequence.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Reach</span>
+            <span class="tile__key">200+ students</span>
+            <span class="tile__desc">Mentored each semester in coding, debugging, and software best practices.</span>
+            <span class="tile__impact">Met lots of cool people and learned a lot for myself.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Curriculum</span>
+            <span class="tile__key">Wrote the assignments</span>
+            <span class="tile__desc">Working with a new instructor, wrote every programming assignment, spec to starter code to solutions, once we settled each topic together.</span>
+            <span class="tile__impact">Built a cool practical intro series to user/item-based collaborative filtering.</span>
+          </li>
+        </ul>
         <ul class="chips" aria-label="Technologies">
           <li>Teaching</li><li>Public Speaking</li><li>Mentorship</li><li>Python</li><li>Java</li><li>Software Development</li>
         </ul>
@@ -275,10 +363,40 @@
         <h3 class="entry__org">CSU Robotics Lab</h3>
         <p class="entry__role">Robotics Research Volunteer</p>
         <div class="entry__text">
-          <p>A year of unpaid, volunteer robotics research at CSU, which I took for the chance to work with expensive hardware. A friend from the video game dev club I'd done game jams with got me into the lab before he transferred schools. The lab had an old ROS-based Fetch robot and a newer ROS2 robot I worked with virtually. My first task was to master the Fetch in simulation: I spent about a month buried in the ROS and Fetch docs, running the demos, and learning the fiddly details, like placing AR tags in Gazebo, catching when configs are in meters versus millimeters, lighting, and driving and monitoring the robot through RViz.</p>
-          <p>Next I checked whether the physical robot still worked, now that the student who had been running it was gone, so I spent several nights verifying that everything I'd done in simulation held up on real hardware, writing scripts to reset the robot to known positions while testing routines and keeping it well clear of obstacles. Late one night, with the building empty, I mapped the lobby of the CS building using ROS's Fetch navigation and mapping nodes, building an occupancy map from the LIDAR and laser scans and marking out no-go zones.</p>
-          <p>On Halloween we ran a demo on that map: Fetch used ROS navigation and localization plus a bit I wrote with YOLO to spot a person, then roamed to a waypoint, looked around, picked someone, rolled up playing Ghostbusters, delivered a Halloween joke in spooky TTS, extended its arm to hand over candy from a pumpkin bucket, and tucked and scurried off to the next waypoint. I also started a project bridging the Unity game engine to ROS2 for research with TurtleBot.</p>
+          <p>A year of volunteer robotics research at CSU, taken for the chance to work with expensive hardware: an old ROS Fetch robot and a newer ROS2 one.</p>
         </div>
+        <ul class="tiles" aria-label="Highlights">
+          <li class="tile">
+            <span class="tile__cat">Simulation</span>
+            <span class="tile__key">Fetch in sim</span>
+            <span class="tile__desc">A month in the ROS and Fetch docs learning to drive and debug the robot in Gazebo and RViz.</span>
+            <span class="tile__impact">Gained the trust and confidence of the head of the lab.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Hardware</span>
+            <span class="tile__key">On the metal</span>
+            <span class="tile__desc">Verified the physical Fetch still worked after its operator left, with scripts to reset it to safe positions.</span>
+            <span class="tile__impact">Lab was ready for robot demos again.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Mapping</span>
+            <span class="tile__key">SLAM the building</span>
+            <span class="tile__desc">Built an occupancy map of the CS building lobby from LIDAR and laser scans, marking no-go zones.</span>
+            <span class="tile__impact">Produced a navigation map that could be used for demos in the computer science lobby.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Demo</span>
+            <span class="tile__key">Halloween demo</span>
+            <span class="tile__desc">Fetch used YOLO to find a person, navigated to them, and handed them candy.</span>
+            <span class="tile__impact">Got the department excited about AI and robotics, and fostered interest in others looking to join the lab.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Integration</span>
+            <span class="tile__key">Unity to ROS2</span>
+            <span class="tile__desc">Started a bridge from the Unity engine to ROS2 for TurtleBot research.</span>
+            <span class="tile__impact">Opened up XR + robotics research options for the lab.</span>
+          </li>
+        </ul>
         <ul class="chips" aria-label="Technologies">
           <li>ROS</li><li>ROS2</li><li>Gazebo</li><li>RViz</li><li>Python 2/3</li><li>YOLO</li><li>Unity</li><li>XR</li><li>LIDAR</li><li>SLAM</li>
         </ul>
@@ -297,11 +415,40 @@
         <h3 class="entry__org">US Marine Corps</h3>
         <p class="entry__role">Refrigeration Technician · Utilities Operations SNCO · Utilities Quality Control SNCO</p>
         <div class="entry__text">
-          <p>I served as a Meritorious Corporal in the 4th Marines, 3rd Marine Division. I started as a refrigeration technician, working air conditioning and HVAC/R, reading schematics, troubleshooting from technical manuals, and repairing equipment, and my scope quickly grew beyond AC to electrical systems, diesel-engine generators, and water purification systems, along with the inventory and maintenance they required.</p>
-          <p>I moved up to Quality Control NCO and effectively became the operator-maintenance manager for the section. Most equipment had tasks the operator was responsible for and others handled at a different echelon, scheduled or corrective, and the program was a mess when I arrived. I brought our entire generator fleet under control: more than fifty AMMPS sets ranging from 1.5kW to 60kW, powered by Cummins, Kubota, and Yanmar engines. I owned the scheduled maintenance while a counterpart handled corrective, tracking technician sheets, scheduling services, moving equipment, and ordering parts through a clunky maintenance system where every level of the chain of command had its own rules for how fields should be filled in and categorized. You would think it could scan a technical manual, match a manufacturer ID, and load the checklists and intervals automatically. It could not. Once it was sorted, it ran smoothly. I was trusted enough with the maintenance-management process that I was also put in charge of the company's combat engineer equipment, heavy demolition and construction gear, even though we had no combat engineers.</p>
-          <p>At MWX, the Marine Corps' largest field exercise, at 29 Palms, I designed the power plan and the full packing list for power operations, plus several on-base operations, and was relied on heavily. After a vehicle rollover I was moved onto tactical driving when I mentioned I held a license, and ran some genuinely gnarly JLTV driving courses. In the field I worked as the engineer, out with a couple of generators, cables, and breakers, constantly packing up, repositioning, and concealing in terrain and canyons during a notional war exercise. My 5kW set started leaking oil around the filter with no way to get parts forward, so I fell back to a far less forgiving backup: a dirty tank with a temperament where you could look at it wrong and it would quit. I spent three days more or less head-down in that machine, working the throttle by hand and siphoning fuel to keep it alive long enough for the comms and fire-support teams to do their jobs.</p>
-          <p>When COVID hit I put in a lot of work keeping that equipment running, and the 4th Marine Regiment's commanding officer, Col. Tracy, awarded me the Soo Chow Creek Medal. He was also the commander who gave me a Meritorious Mast for taking first place in the company shooting competition. The top shooters went on to compete against the Japan Ground Self-Defense Force in a joint match that even had US special forces in it; we lost, but it was an incredible experience. I also carried color guard for my company as the left rifle bearer, scored a 292/300 PFT, earned meritorious promotions, volunteered on beach cleanups, and took Japanese classes. I chipped away at online coursework the whole time, once finishing a class from the field, and started coding in 2021 with JavaScript on freeCodeCamp.</p>
+          <p>Four years in the Marine Corps, 4th Marines, 3rd Marine Division, as a Meritorious Corporal. I went from fixing refrigeration to managing maintenance for a whole fleet of utilities gear, and started coding in my off time.</p>
         </div>
+        <ul class="tiles" aria-label="Highlights">
+          <li class="tile">
+            <span class="tile__cat">Craft</span>
+            <span class="tile__key">Refrigeration tech</span>
+            <span class="tile__desc">HVAC/R, schematics, and troubleshooting that grew into generators, electrical, and water purification.</span>
+            <span class="tile__impact">Became a go-to across the section's utilities gear.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Leadership</span>
+            <span class="tile__key">50+ generator fleet</span>
+            <span class="tile__desc">As Quality Control NCO, brought the AMMPS fleet (1.5–60kW) back under control from a broken program.</span>
+            <span class="tile__impact">Kept the fleet mission-ready and the maintenance program running clean.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Field ops</span>
+            <span class="tile__key">MWX power plan</span>
+            <span class="tile__desc">Designed the power plan and packing list for the Corps' largest field exercise, at 29 Palms.</span>
+            <span class="tile__impact">Powered major forward establishments in exercise.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Field</span>
+            <span class="tile__key">Kept power up</span>
+            <span class="tile__desc">Nursed a failing backup generator by hand for three days when no parts could reach the field.</span>
+            <span class="tile__impact">Comms and fire-support teams stayed online and our forward COC remained notionally alive.</span>
+          </li>
+          <li class="tile">
+            <span class="tile__cat">Recognition</span>
+            <span class="tile__key">Soochow Creek Medal</span>
+            <span class="tile__desc">Awarded for keeping maintenance running through COVID, with meritorious promotions and a 292/300 PFT.</span>
+            <span class="tile__impact">Recognized at the regimental level for the work.</span>
+          </li>
+        </ul>
         <ul class="chips" aria-label="Technologies">
           <li>Leadership</li><li>Maintenance Management</li><li>Power Generation</li><li>HVAC/R</li><li>Diesel Generators</li><li>Electrical Systems</li><li>Troubleshooting</li><li>Logistics</li>
         </ul>
@@ -350,17 +497,17 @@
   </div>
 
   <dl class="skills-grid">
-    <div class="skillrow reveal-up"><dt>Languages</dt><dd>Python, TypeScript, JavaScript, Java</dd></div>
-    <div class="skillrow reveal-up"><dt>Frontend</dt><dd>React, Next.js</dd></div>
-    <div class="skillrow reveal-up"><dt>Backend</dt><dd>Node.js, Express, NestJS, FastAPI, Flask</dd></div>
-    <div class="skillrow reveal-up"><dt>Databases &amp; ORM</dt><dd>PostgreSQL, Prisma, MongoDB, ChromaDB</dd></div>
-    <div class="skillrow reveal-up"><dt>Cloud &amp; DevOps</dt><dd>GCP, AWS, Azure, Cloud Run, Docker, GitHub Actions, CI/CD</dd></div>
-    <div class="skillrow reveal-up"><dt>AI &amp; Agents</dt><dd>Agentic AI, RAG, MCP, OpenAI API, OpenRouter, Structured Output, mem0, Reinforcement Learning</dd></div>
-    <div class="skillrow reveal-up"><dt>Robotics &amp; CV</dt><dd>ROS, ROS2, Gazebo, RViz, YOLO, Unity, Computer Vision</dd></div>
-    <div class="skillrow reveal-up"><dt>Integrations &amp; Realtime</dt><dd>Pipedream, Stripe, Vapi, Firebase, WebSockets, Canvas API, Selenium</dd></div>
-    <div class="skillrow reveal-up"><dt>Data &amp; Distributed Systems</dt><dd>Distributed Systems, Peer-to-Peer Systems, Spark, HDFS, Data Visualization</dd></div>
-    <div class="skillrow reveal-up"><dt>Methodologies</dt><dd>TDD, Agile, Git</dd></div>
-    <div class="skillrow reveal-up"><dt>Soft Skills</dt><dd>Communication, Leadership, Problem-Solving, Mentorship</dd></div>
+    <div class="skillrow reveal-up"><dt>Languages</dt><dd><span>Python</span><span>TypeScript</span><span>JavaScript</span><span>Java</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Frontend</dt><dd><span>React</span><span>Next.js</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Backend</dt><dd><span>Node.js</span><span>Express</span><span>NestJS</span><span>FastAPI</span><span>Flask</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Databases &amp; ORM</dt><dd><span>PostgreSQL</span><span>Prisma</span><span>MongoDB</span><span>ChromaDB</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Cloud &amp; DevOps</dt><dd><span>GCP</span><span>AWS</span><span>Azure</span><span>Cloud Run</span><span>Docker</span><span>GitHub Actions</span><span>CI/CD</span></dd></div>
+    <div class="skillrow reveal-up"><dt>AI &amp; Agents</dt><dd><span>Agentic AI</span><span>RAG</span><span>MCP</span><span>OpenAI API</span><span>OpenRouter</span><span>Structured Output</span><span>mem0</span><span>Reinforcement Learning</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Robotics &amp; CV</dt><dd><span>ROS</span><span>ROS2</span><span>Gazebo</span><span>RViz</span><span>YOLO</span><span>Unity</span><span>Computer Vision</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Integrations &amp; Realtime</dt><dd><span>Pipedream</span><span>Stripe</span><span>Vapi</span><span>Firebase</span><span>WebSockets</span><span>Canvas API</span><span>Selenium</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Data &amp; Distributed Systems</dt><dd><span>Distributed Systems</span><span>Peer-to-Peer Systems</span><span>Spark</span><span>HDFS</span><span>Data Visualization</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Methodologies</dt><dd><span>TDD</span><span>Agile</span><span>Git</span></dd></div>
+    <div class="skillrow reveal-up"><dt>Soft Skills</dt><dd><span>Communication</span><span>Leadership</span><span>Problem-Solving</span><span>Mentorship</span></dd></div>
   </dl>
 </section>
 


### PR DESCRIPTION
Cuts the LinkedIn-style long-form copy across the site down to bite-size, scannable pieces with more visual pop.

## What changed
- **Experience entries** (all 6): each is now a one-line lede plus a grid of **impact tiles** — cyan category → glowing gold keyword → plain-language detail → inferred impact line. Reads in one scan instead of paragraphs.
- **Skills**: 11 color-coded categories, each rendered as glowing chips in its own neon hue, so color also groups the skills.
- **Tech chips** (experience + projects): cycle the same neon palette instead of flat gray.
- **Service Record**: ribbon-colored top bars on each panel, gold title accents, and small gold ribbon-bar markers on each award.

All tints derive from a single per-item `--c` var via `color-mix`, so hues are one-line tweaks. Respects `prefers-reduced-motion`. No em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)