### PR TITLE
Link WarTable and HYVV to their sites

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -625,6 +625,8 @@ main, .nav, .foot { position: relative; z-index: 2; }
   font-size: clamp(1.7rem, 3.2vw, 2.5rem); line-height: 1.08;
   color: var(--star); margin-bottom: .35rem;
 }
+.entry__org a { text-decoration: underline; text-decoration-color: var(--gold-soft); text-underline-offset: .18em; transition: color .2s; }
+.entry__org a:hover { color: var(--gold); }
 .entry__role {
   font-family: var(--f-mono); font-size: .82rem; letter-spacing: .03em;
   color: var(--gold-soft); margin-bottom: 1.5rem;

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
         <time class="entry__date">Jul 2025 – Jun 2026</time>
       </div>
       <div class="entry__main">
-        <h3 class="entry__org">WarTable by Freestyle Consulting</h3>
+        <h3 class="entry__org"><a href="https://wartable.ai" target="_blank" rel="noopener">WarTable</a> by Freestyle Consulting</h3>
         <p class="entry__role">Software Engineer (Full-Stack &amp; DevOps), Contract</p>
         <div class="entry__text">
           <p>WarTable is an AI platform for small businesses. I took it from an empty repo to a live, monetized product with paying users, owning every layer myself.</p>
@@ -234,7 +234,7 @@
         <time class="entry__date">Dec 2024 – Dec 2025</time>
       </div>
       <div class="entry__main">
-        <h3 class="entry__org">HYVV</h3>
+        <h3 class="entry__org"><a href="https://hyvv.io" target="_blank" rel="noopener">HYVV</a></h3>
         <p class="entry__role">Software Engineer (Full-Stack &amp; DevOps), Contract</p>
         <div class="entry__text">
           <p>HYVV is a business platform. I built its first AI features, then took over the entire development pipeline when the rest of the team left.</p>


### PR DESCRIPTION
Links "WarTable" to wartable.ai and "HYVV" to hyvv.io in the experience headings (new tab, noopener). Adds a gold underline + hover style so they read as links, matching the contact-link pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)