### PR TITLE
Flight mode: slither.io-style pointer steering, ditch the d-pad

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,7 +39,8 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; background: #000; }
-html.flying { scroll-behavior: auto; touch-action: none; }
+html.flying { scroll-behavior: auto; touch-action: none; overscroll-behavior: none; }
+html.flying body { touch-action: none; overscroll-behavior: none; }
 
 body {
   font-family: var(--f-body);

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -159,7 +159,20 @@ main, .nav, .foot { position: relative; z-index: 2; }
   filter: drop-shadow(0 4px 10px rgba(0,0,0,0.45)) drop-shadow(0 0 14px rgba(127,214,232,0.45));
 }
 .rocket[hidden] { display: none; }
-.rocket__svg { display: block; overflow: visible; }
+.rocket__svg { display: block; overflow: visible; width: 100%; height: 100%; }
+
+/* smaller ship on small/touch screens — mirrors SHIP_SCALE in main.js */
+@media (max-width: 600px), (pointer: coarse) {
+  .rocket {
+    width: 35px; height: 60px;
+    margin-left: -17px; margin-top: -30px;
+  }
+  .rocket__flame {
+    top: 55px;
+    width: calc(8px + 5px * var(--thrust));
+    height: calc(4px + 22px * var(--thrust));
+  }
+}
 
 /* afterburner — boosting (Shift, or double-click/tap and hold) */
 .rocket.is-boosting {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,7 +39,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; background: #000; }
-html.flying { scroll-behavior: auto; }
+html.flying { scroll-behavior: auto; touch-action: none; }
 
 body {
   font-family: var(--f-body);
@@ -160,7 +160,7 @@ main, .nav, .foot { position: relative; z-index: 2; }
 .rocket[hidden] { display: none; }
 .rocket__svg { display: block; overflow: visible; }
 
-/* afterburner — Shift held */
+/* afterburner — boosting (Shift, or double-click/tap and hold) */
 .rocket.is-boosting {
   filter: drop-shadow(0 4px 12px rgba(0,0,0,0.5)) drop-shadow(0 0 22px rgba(127,214,232,0.85));
 }
@@ -186,30 +186,6 @@ main, .nav, .foot { position: relative; z-index: 2; }
 @keyframes flameFlicker {
   0%   { transform: translateX(-50%) scaleY(1) scaleX(1); }
   100% { transform: translateX(-52%) scaleY(0.86) scaleX(1.12); }
-}
-
-/* on-screen d-pad (touch) */
-.dpad {
-  position: fixed; right: 1.1rem; bottom: 1.4rem; z-index: 66;
-  display: none;
-  grid-template-columns: repeat(3, 48px); grid-template-rows: repeat(3, 48px);
-  gap: 6px; touch-action: none;
-}
-.dpad[hidden] { display: none !important; }
-.dpad__btn {
-  display: flex; align-items: center; justify-content: center;
-  font-size: 1rem; color: var(--star); cursor: pointer;
-  background: rgba(7,10,22,0.7); backdrop-filter: blur(10px);
-  border: 1px solid var(--line); border-radius: 12px;
-  -webkit-user-select: none; user-select: none;
-}
-.dpad__btn:active { background: rgba(127,214,232,0.25); border-color: var(--cyan); }
-.dpad__up    { grid-column: 2; grid-row: 1; }
-.dpad__left  { grid-column: 1; grid-row: 2; }
-.dpad__right { grid-column: 3; grid-row: 2; }
-.dpad__down  { grid-column: 2; grid-row: 3; }
-@media (hover: none) and (pointer: coarse) {
-  .dpad.is-on { display: grid; }
 }
 
 /* ============================================================

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -646,7 +646,13 @@
         let ay = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
         let wantBoost = keys.boost;
         if (ax === 0 && ay === 0 && steering) {
-          const dx = targetX - px, dy = targetY - py, d = Math.hypot(dx, dy);
+          // steer toward the pointer, but take the SHORTEST path around the
+          // horizontal seam — crossing an edge and wrapping when that's
+          // closer than flying back across the whole screen.
+          const wrapW = innerWidth + H_MARGIN * 2;
+          let dx = targetX - px;
+          dx = ((dx + wrapW / 2) % wrapW + wrapW) % wrapW - wrapW / 2;
+          const dy = targetY - py, d = Math.hypot(dx, dy);
           if (d > 4) { ax = dx / d; ay = dy / d; }
           wantBoost = wantBoost || pointerBoost;
         }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -220,7 +220,7 @@
     const ACCEL = 2200;     // px/s^2 of thrust
     const DAMP = 2.6;       // velocity damping per second
     const MAXV = 1100;      // px/s speed cap
-    const H_MARGIN = 36 * SHIP_SCALE; // off-screen buffer before the rocket wraps to the opposite side
+    const H_TETHER = Math.min(90, innerWidth * 0.12); // horizontal leash radius around screen-center — exceeding it pans the world camera (camX) instead, keeping the rocket near center (tighter on narrow phones so it doesn't drift to the edges)
     const V_TETHER = 70;    // vertical leash radius around screen-center — exceeding it scrolls the page instead, keeping the rocket tethered near center like slither.io
     const BOOST_ACCEL = 2;  // thrust multiplier while Shift is held
     const BOOST_MAXV = 2100; // raised speed cap while boosting
@@ -237,6 +237,7 @@
     let active = false;
     let raf = 0, last = 0, sp = 0;
     let px = 0, py = 0, vx = 0, vy = 0, rot = 0, thrust = 0;
+    let camX = 0;   // horizontal world-camera offset — the page can't scroll sideways, so panning this keeps the rocket centered while the alien world slides past
     let gdpr = 1, gw = 0, gh = 0;
     const keys = { up: false, down: false, left: false, right: false, boost: false };
     // pointer/touch steering — click or tap in front of the ship to move
@@ -330,11 +331,12 @@
     function spawnFoe() {
       const m = 60, edge = Math.floor(Math.random() * 4), sc = window.scrollY;
       let x, y;
-      // y is stored in world (page) space, so spawn around the current view
-      if (edge === 0) { x = Math.random() * gw; y = sc - m; }
-      else if (edge === 1) { x = gw + m; y = sc + Math.random() * gh; }
-      else if (edge === 2) { x = Math.random() * gw; y = sc + gh + m; }
-      else { x = -m; y = sc + Math.random() * gh; }
+      // entities live in world space; spawn around the current camera view
+      // (camX horizontally, scroll vertically)
+      if (edge === 0) { x = camX + Math.random() * gw; y = sc - m; }
+      else if (edge === 1) { x = camX + gw + m; y = sc + Math.random() * gh; }
+      else if (edge === 2) { x = camX + Math.random() * gw; y = sc + gh + m; }
+      else { x = camX - m; y = sc + Math.random() * gh; }
       const tough = Math.random() < Math.min(0.4, gTime * 0.006);
       foes.push({ x, y, vx: 0, vy: 0, r: (tough ? 21 : 15) * SHIP_SCALE, hp: tough ? 3 : 1, hue: tough ? "gold" : "rose", shoot: 0.8 + Math.random() * 1.4, wob: Math.random() * 6.2832 });
     }
@@ -345,7 +347,7 @@
       shots++;
       const rad = rot * Math.PI / 180;
       const dx = Math.sin(rad), dy = -Math.cos(rad);
-      pBullets.push({ x: px + dx * 28 * SHIP_SCALE, y: (py + window.scrollY) + dy * 28 * SHIP_SCALE, vx: dx * BULLET_V + vx * 0.3, vy: dy * BULLET_V + vy * 0.3, life: 1.1 });
+      pBullets.push({ x: (px + camX) + dx * 28 * SHIP_SCALE, y: (py + window.scrollY) + dy * 28 * SHIP_SCALE, vx: dx * BULLET_V + vx * 0.3, vy: dy * BULLET_V + vy * 0.3, life: 1.1 });
       vx -= dx * 26; vy -= dy * 26;            // gentle recoil
       beep(660, 0.07, "square", 0.025, 240);
     }
@@ -477,7 +479,7 @@
 
       // player position in world (page) space — foes/bullets live in world space
       const sc = window.scrollY;
-      const pwx = px, pwy = py + sc;
+      const pwx = px + camX, pwy = py + sc;
 
       const foeSpeed = Math.min(330, 150 + gTime * 2.4);
       for (let i = foes.length - 1; i >= 0; i--) {
@@ -510,8 +512,8 @@
       for (let i = pBullets.length - 1; i >= 0; i--) {
         const b = pBullets[i];
         b.x += b.vx * dt; b.y += b.vy * dt; b.life -= dt;
-        const by = b.y - sc;
-        let gone = b.life <= 0 || b.x < -30 || b.x > gw + 30 || by < -30 || by > gh + 30;
+        const by = b.y - sc, bx = b.x - camX;
+        let gone = b.life <= 0 || bx < -30 || bx > gw + 30 || by < -30 || by > gh + 30;
         for (let j = foes.length - 1; j >= 0 && !gone; j--) {
           const f = foes[j];
           if (Math.hypot(b.x - f.x, b.y - f.y) < f.r + 5) {
@@ -536,8 +538,8 @@
         const d = Math.hypot(b.x - pwx, b.y - pwy);
         if (alive && d < PLAYER_R) { fBullets.splice(i, 1); hitPlayer(10); continue; }
         if (alive && !b.grazed && d < GRAZE_R) { b.grazed = true; grazes++; }
-        const by2 = b.y - sc;
-        if (b.life <= 0 || b.x < -40 || b.x > gw + 40 || by2 < -40 || by2 > gh + 40) fBullets.splice(i, 1);
+        const by2 = b.y - sc, bx2 = b.x - camX;
+        if (b.life <= 0 || bx2 < -40 || bx2 > gw + 40 || by2 < -40 || by2 > gh + 40) fBullets.splice(i, 1);
       }
 
       // particles
@@ -593,9 +595,10 @@
       gctx.setTransform(gdpr, 0, 0, gdpr, 0, 0);
       gctx.clearRect(0, 0, gw, gh);
       gctx.save();
-      // entities are stored in world (page) space; shift up by the scroll so
-      // they stay pinned to the background and can scroll out of view
-      gctx.translate(shakeX, shakeY - window.scrollY);
+      // entities are stored in world space; shift by the camera (camX
+      // horizontally, scroll vertically) so they stay pinned to the world
+      // and slide out of view as the rocket moves
+      gctx.translate(shakeX - camX, shakeY - window.scrollY);
 
       for (const b of fBullets) {
         const g = gctx.createRadialGradient(b.x, b.y, 0, b.x, b.y, 9);
@@ -646,13 +649,9 @@
         let ay = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
         let wantBoost = keys.boost;
         if (ax === 0 && ay === 0 && steering) {
-          // steer toward the pointer, but take the SHORTEST path around the
-          // horizontal seam — crossing an edge and wrapping when that's
-          // closer than flying back across the whole screen.
-          const wrapW = innerWidth + H_MARGIN * 2;
-          let dx = targetX - px;
-          dx = ((dx + wrapW / 2) % wrapW + wrapW) % wrapW - wrapW / 2;
-          const dy = targetY - py, d = Math.hypot(dx, dy);
+          // heading toward the pointer, measured from the rocket's tethered
+          // near-center position — like steering a slither.io snake.
+          const dx = targetX - px, dy = targetY - py, d = Math.hypot(dx, dy);
           if (d > 4) { ax = dx / d; ay = dy / d; }
           wantBoost = wantBoost || pointerBoost;
         }
@@ -670,11 +669,14 @@
         if (sp > maxv) { vx = vx / sp * maxv; vy = vy / sp * maxv; sp = maxv; }
         rocket.classList.toggle("is-boosting", boosting);
 
-        // horizontal: wrap around the sides — fly off one edge, reappear on
-        // the other, torus-style. No bounce, no hard boundary.
+        // horizontal: keep the rocket tethered near screen-center; overflow
+        // pans the world camera so the aliens slide past instead of the
+        // rocket flying off to the edge. No page scroll exists sideways.
         px += vx * dt;
-        const wrapW = innerWidth + H_MARGIN * 2;
-        px = ((px + H_MARGIN) % wrapW + wrapW) % wrapW - H_MARGIN;
+        const cx = innerWidth / 2;
+        const xMin = cx - H_TETHER, xMax = cx + H_TETHER;
+        if (px > xMax) { camX += px - xMax; px = xMax; }
+        else if (px < xMin) { camX -= xMin - px; px = xMin; }
 
         // vertical: stay tethered near screen-center; overflow scrolls the
         // page instead, so the world moves past the rocket, slither.io-style.
@@ -731,7 +733,7 @@
     }
 
     function resetGame() {
-      px = innerWidth / 2; py = innerHeight / 2;
+      px = innerWidth / 2; py = innerHeight / 2; camX = 0;
       vx = 0; vy = -MAXV * 0.5; rot = 0; thrust = 1;
       hp = MAXHP; alive = true; dead = false;
       gTime = 0; dist = 0; kills = 0; shots = 0; hits = 0; grazes = 0;
@@ -848,9 +850,8 @@
     window.addEventListener("resize", () => {
       if (!active) return;
       sizeGame();
-      const cy = innerHeight / 2;
-      const wrapW = innerWidth + H_MARGIN * 2;
-      px = ((px + H_MARGIN) % wrapW + wrapW) % wrapW - H_MARGIN;
+      const cx = innerWidth / 2, cy = innerHeight / 2;
+      px = clamp(px, cx - H_TETHER, cx + H_TETHER);
       py = clamp(py, cy - V_TETHER, cy + V_TETHER);
     }, { passive: true });
   })();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -220,8 +220,8 @@
     const ACCEL = 2200;     // px/s^2 of thrust
     const DAMP = 2.6;       // velocity damping per second
     const MAXV = 1100;      // px/s speed cap
-    const H_MARGIN = 36 * SHIP_SCALE; // how close the rocket can get to the left/right edges
-    const V_TETHER = 100;   // vertical leash radius around screen-center — exceeding it scrolls the page instead, keeping the rocket tethered near center like slither.io
+    const H_MARGIN = 36 * SHIP_SCALE; // off-screen buffer before the rocket wraps to the opposite side
+    const V_TETHER = 70;    // vertical leash radius around screen-center — exceeding it scrolls the page instead, keeping the rocket tethered near center like slither.io
     const BOOST_ACCEL = 2;  // thrust multiplier while Shift is held
     const BOOST_MAXV = 2100; // raised speed cap while boosting
 
@@ -280,6 +280,7 @@
     ];
 
     function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+    function maxScrollY() { return Math.max(0, document.documentElement.scrollHeight - innerHeight); }
 
     function lerpAngle(a, b, t) {
       let d = ((b - a + 540) % 360) - 180;
@@ -663,14 +664,16 @@
         if (sp > maxv) { vx = vx / sp * maxv; vy = vy / sp * maxv; sp = maxv; }
         rocket.classList.toggle("is-boosting", boosting);
 
-        // horizontal: move within the viewport, soft-bounce off the sides
+        // horizontal: wrap around the sides — fly off one edge, reappear on
+        // the other, torus-style. No bounce, no hard boundary.
         px += vx * dt;
-        const xMin = H_MARGIN, xMax = innerWidth - H_MARGIN;
-        if (px < xMin) { px = xMin; vx = Math.abs(vx) * 0.4; }
-        else if (px > xMax) { px = xMax; vx = -Math.abs(vx) * 0.4; }
+        const wrapW = innerWidth + H_MARGIN * 2;
+        px = ((px + H_MARGIN) % wrapW + wrapW) % wrapW - H_MARGIN;
 
         // vertical: stay tethered near screen-center; overflow scrolls the
         // page instead, so the world moves past the rocket, slither.io-style.
+        // Hitting the top/bottom of the page wraps to the other end instead
+        // of stalling, so the whole page behaves like a torus too.
         py += vy * dt;
         const cy = innerHeight / 2;
         const yMin = cy - V_TETHER, yMax = cy + V_TETHER;
@@ -679,15 +682,15 @@
           const before = window.scrollY;
           window.scrollBy(0, over);
           const moved = window.scrollY - before;
-          py = yMax + (over - moved);
-          if (moved < over - 0.5) vy *= 0.6;
+          if (moved < over - 0.5) window.scrollTo(0, 0);
+          py = yMax;
         } else if (py < yMin) {
           const over = yMin - py;
           const before = window.scrollY;
           window.scrollBy(0, -over);
           const moved = before - window.scrollY;
-          py = yMin - (over - moved);
-          if (moved < over - 0.5) vy *= 0.6;
+          if (moved < over - 0.5) window.scrollTo(0, maxScrollY());
+          py = yMin;
         }
         py = clamp(py, 6, innerHeight - 6);
 
@@ -840,7 +843,8 @@
       if (!active) return;
       sizeGame();
       const cy = innerHeight / 2;
-      px = clamp(px, H_MARGIN, innerWidth - H_MARGIN);
+      const wrapW = innerWidth + H_MARGIN * 2;
+      px = ((px + H_MARGIN) % wrapW + wrapW) % wrapW - H_MARGIN;
       py = clamp(py, cy - V_TETHER, cy + V_TETHER);
     }, { passive: true });
   })();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -211,11 +211,16 @@
     const goAgain = document.getElementById("goAgain");
     const goClose = document.getElementById("goClose");
 
+    // display scale — shrink ships & hitboxes on small/touch screens so the
+    // play area feels less cramped
+    const isMobile = window.matchMedia("(max-width: 600px), (pointer: coarse)").matches;
+    const SHIP_SCALE = isMobile ? 0.72 : 1;
+
     // flight physics
     const ACCEL = 2200;     // px/s^2 of thrust
     const DAMP = 2.6;       // velocity damping per second
     const MAXV = 1100;      // px/s speed cap
-    const H_MARGIN = 36;    // how close the rocket can get to the left/right edges
+    const H_MARGIN = 36 * SHIP_SCALE; // how close the rocket can get to the left/right edges
     const V_TETHER = 100;   // vertical leash radius around screen-center — exceeding it scrolls the page instead, keeping the rocket tethered near center like slither.io
     const BOOST_ACCEL = 2;  // thrust multiplier while Shift is held
     const BOOST_MAXV = 2100; // raised speed cap while boosting
@@ -226,6 +231,8 @@
     const BULLET_V = 980;      // player bullet speed
     const FOE_BULLET_V = 360;  // alien bullet speed
     const MOVE_FIRE_SPEED = 40; // gun auto-fires once speed exceeds this
+    const PLAYER_R = 14 * SHIP_SCALE; // player hit radius, matches the (possibly shrunk) sprite
+    const GRAZE_R = 34 * SHIP_SCALE;  // near-miss radius for the "Close Shave" achievement
 
     let active = false;
     let raf = 0, last = 0, sp = 0;
@@ -328,7 +335,7 @@
       else if (edge === 2) { x = Math.random() * gw; y = sc + gh + m; }
       else { x = -m; y = sc + Math.random() * gh; }
       const tough = Math.random() < Math.min(0.4, gTime * 0.006);
-      foes.push({ x, y, vx: 0, vy: 0, r: tough ? 21 : 15, hp: tough ? 3 : 1, hue: tough ? "gold" : "rose", shoot: 0.8 + Math.random() * 1.4, wob: Math.random() * 6.2832 });
+      foes.push({ x, y, vx: 0, vy: 0, r: (tough ? 21 : 15) * SHIP_SCALE, hp: tough ? 3 : 1, hue: tough ? "gold" : "rose", shoot: 0.8 + Math.random() * 1.4, wob: Math.random() * 6.2832 });
     }
 
     function tryShoot() {
@@ -337,7 +344,7 @@
       shots++;
       const rad = rot * Math.PI / 180;
       const dx = Math.sin(rad), dy = -Math.cos(rad);
-      pBullets.push({ x: px + dx * 28, y: (py + window.scrollY) + dy * 28, vx: dx * BULLET_V + vx * 0.3, vy: dy * BULLET_V + vy * 0.3, life: 1.1 });
+      pBullets.push({ x: px + dx * 28 * SHIP_SCALE, y: (py + window.scrollY) + dy * 28 * SHIP_SCALE, vx: dx * BULLET_V + vx * 0.3, vy: dy * BULLET_V + vy * 0.3, life: 1.1 });
       vx -= dx * 26; vy -= dy * 26;            // gentle recoil
       beep(660, 0.07, "square", 0.025, 240);
     }
@@ -490,7 +497,7 @@
           beep(170, 0.12, "sawtooth", 0.016, 90);
         }
 
-        if (alive && d < f.r + 14) {              // rammed the player
+        if (alive && d < f.r + PLAYER_R) {        // rammed the player
           explode(f.x, f.y, f.hue, 18);
           foes.splice(i, 1); kills++;
           hitPlayer(22);
@@ -526,8 +533,8 @@
         const b = fBullets[i];
         b.x += b.vx * dt; b.y += b.vy * dt; b.life -= dt;
         const d = Math.hypot(b.x - pwx, b.y - pwy);
-        if (alive && d < 14) { fBullets.splice(i, 1); hitPlayer(10); continue; }
-        if (alive && !b.grazed && d < 34) { b.grazed = true; grazes++; }
+        if (alive && d < PLAYER_R) { fBullets.splice(i, 1); hitPlayer(10); continue; }
+        if (alive && !b.grazed && d < GRAZE_R) { b.grazed = true; grazes++; }
         const by2 = b.y - sc;
         if (b.life <= 0 || b.x < -40 || b.x > gw + 40 || by2 < -40 || by2 > gh + 40) fBullets.splice(i, 1);
       }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -815,6 +815,16 @@
     window.addEventListener("pointerup", endSteer);
     window.addEventListener("pointercancel", endSteer);
 
+    // Safari doesn't reliably honor preventDefault() on pointer events for
+    // scroll suppression, so also block the underlying touch gesture
+    // directly — the game already drives page scroll itself in step().
+    window.addEventListener("touchstart", (e) => {
+      if (active && !dead && !isChrome(e.target)) e.preventDefault();
+    }, { passive: false });
+    window.addEventListener("touchmove", (e) => {
+      if (active) e.preventDefault();
+    }, { passive: false });
+
     // keep things on screen / sized when the window changes
     window.addEventListener("resize", () => {
       if (!active) return;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -215,7 +215,8 @@
     const ACCEL = 2200;     // px/s^2 of thrust
     const DAMP = 2.6;       // velocity damping per second
     const MAXV = 1100;      // px/s speed cap
-    const MARGIN = 70;      // how close the rocket gets to viewport edges
+    const H_MARGIN = 36;    // how close the rocket can get to the left/right edges
+    const V_TETHER = 100;   // vertical leash radius around screen-center — exceeding it scrolls the page instead, keeping the rocket tethered near center like slither.io
     const BOOST_ACCEL = 2;  // thrust multiplier while Shift is held
     const BOOST_MAXV = 2100; // raised speed cap while boosting
 
@@ -643,27 +644,29 @@
         }
         const boosting = wantBoost && (ax !== 0 || ay !== 0);
 
-        const accel = ACCEL * (keys.boost ? BOOST_ACCEL : 1);
+        const accel = ACCEL * (wantBoost ? BOOST_ACCEL : 1);
         vx += ax * accel * dt;
         vy += ay * accel * dt;
 
         const damp = Math.exp(-DAMP * dt);
         vx *= damp; vy *= damp;
 
-        const maxv = keys.boost ? BOOST_MAXV : MAXV;
+        const maxv = wantBoost ? BOOST_MAXV : MAXV;
         sp = Math.hypot(vx, vy);
         if (sp > maxv) { vx = vx / sp * maxv; vy = vy / sp * maxv; sp = maxv; }
         rocket.classList.toggle("is-boosting", boosting);
 
         // horizontal: move within the viewport, soft-bounce off the sides
         px += vx * dt;
-        const xMin = MARGIN, xMax = innerWidth - MARGIN;
+        const xMin = H_MARGIN, xMax = innerWidth - H_MARGIN;
         if (px < xMin) { px = xMin; vx = Math.abs(vx) * 0.4; }
         else if (px > xMax) { px = xMax; vx = -Math.abs(vx) * 0.4; }
 
-        // vertical: stay inside the band; overflow drives the page scroll.
+        // vertical: stay tethered near screen-center; overflow scrolls the
+        // page instead, so the world moves past the rocket, slither.io-style.
         py += vy * dt;
-        const yMin = MARGIN, yMax = innerHeight - MARGIN;
+        const cy = innerHeight / 2;
+        const yMin = cy - V_TETHER, yMax = cy + V_TETHER;
         if (py > yMax) {
           const over = py - yMax;
           const before = window.scrollY;
@@ -712,7 +715,7 @@
     }
 
     function resetGame() {
-      px = innerWidth / 2; py = innerHeight - MARGIN;
+      px = innerWidth / 2; py = innerHeight / 2;
       vx = 0; vy = -MAXV * 0.5; rot = 0; thrust = 1;
       hp = MAXHP; alive = true; dead = false;
       gTime = 0; dist = 0; kills = 0; shots = 0; hits = 0; grazes = 0;
@@ -829,8 +832,9 @@
     window.addEventListener("resize", () => {
       if (!active) return;
       sizeGame();
-      px = clamp(px, MARGIN, innerWidth - MARGIN);
-      py = clamp(py, MARGIN, innerHeight - MARGIN);
+      const cy = innerHeight / 2;
+      px = clamp(px, H_MARGIN, innerWidth - H_MARGIN);
+      py = clamp(py, cy - V_TETHER, cy + V_TETHER);
     }, { passive: true });
   })();
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -181,9 +181,11 @@
   }
 
   /* ============================================================
-     Flight mode → COSMIC SKIRMISH — drive a rocket with WASD /
-     arrows (flying past the comfort band scrolls the page), shoot
-     with click or Space, and survive waves of alien saucers that
+     Flight mode → COSMIC SKIRMISH — drive a rocket by clicking or
+     tapping in front of it; it steers toward the pointer while
+     held, slither.io style (works the same on mouse or touch).
+     Double-click/tap and hold to boost. The gun fires automatically
+     while moving, and the rocket chases waves of alien saucers that
      chase and fire back. Track survival time, kills, distance and
      unlock achievements along the way.
      ============================================================ */
@@ -191,7 +193,6 @@
     const btn = document.getElementById("flyBtn");
     const rocket = document.getElementById("rocket");
     const flame = rocket && rocket.querySelector(".rocket__flame");
-    const dpad = document.getElementById("dpad");
     if (!btn || !rocket || !flame) return;
 
     // game DOM
@@ -223,13 +224,18 @@
     const FIRE_CD = 0.16;      // seconds between player shots
     const BULLET_V = 980;      // player bullet speed
     const FOE_BULLET_V = 360;  // alien bullet speed
-    const isTouch = window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+    const MOVE_FIRE_SPEED = 40; // gun auto-fires once speed exceeds this
 
     let active = false;
     let raf = 0, last = 0, sp = 0;
     let px = 0, py = 0, vx = 0, vy = 0, rot = 0, thrust = 0;
     let gdpr = 1, gw = 0, gh = 0;
-    const keys = { up: false, down: false, left: false, right: false, boost: false, fire: false };
+    const keys = { up: false, down: false, left: false, right: false, boost: false };
+    // pointer/touch steering — click or tap in front of the ship to move
+    // toward it (held = keep steering); a second tap within the double-tap
+    // window engages boost for as long as it's held.
+    let steering = false, pointerBoost = false, targetX = 0, targetY = 0;
+    let lastTapTime = 0, lastTapX = 0, lastTapY = 0;
 
     // run state
     let hp, alive, dead;
@@ -353,7 +359,8 @@
       explode(px, wy, "gold", 40); explode(px, wy, "rose", 26); explode(px, wy, "white", 16);
       shake = 18;
       rocket.hidden = true;
-      keys.up = keys.down = keys.left = keys.right = keys.boost = keys.fire = false;
+      keys.up = keys.down = keys.left = keys.right = keys.boost = false;
+      steering = false; pointerBoost = false;
       beep(90, 0.6, "sawtooth", 0.09, 30);
       saveBest();
       setTimeout(() => { if (active && dead) showOverlay(); }, 850);
@@ -450,7 +457,7 @@
         noHit += dt;
         if (sp > topSpeed) topSpeed = sp;
         if (!reachedBottom && window.scrollY + innerHeight >= document.documentElement.scrollHeight - 3) reachedBottom = true;
-        if (keys.fire || isTouch) tryShoot();
+        if (sp > MOVE_FIRE_SPEED) tryShoot();
 
         spawnT -= dt;
         const maxFoes = Math.min(11, 3 + Math.floor(gTime / 11));
@@ -626,9 +633,15 @@
       last = now;
 
       if (alive) {
-        const ax = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
-        const ay = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
-        const boosting = keys.boost && (ax !== 0 || ay !== 0);
+        let ax = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
+        let ay = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
+        let wantBoost = keys.boost;
+        if (ax === 0 && ay === 0 && steering) {
+          const dx = targetX - px, dy = targetY - py, d = Math.hypot(dx, dy);
+          if (d > 4) { ax = dx / d; ay = dy / d; }
+          wantBoost = wantBoost || pointerBoost;
+        }
+        const boosting = wantBoost && (ax !== 0 || ay !== 0);
 
         const accel = ACCEL * (keys.boost ? BOOST_ACCEL : 1);
         vx += ax * accel * dt;
@@ -708,7 +721,8 @@
       foes = []; pBullets = []; fBullets = []; parts = [];
       spawnT = 0.6; fireT = 0; shake = 0; shakeX = 0; shakeY = 0;
       unlocked.clear(); earned.length = 0;
-      keys.up = keys.down = keys.left = keys.right = keys.boost = keys.fire = false;
+      keys.up = keys.down = keys.left = keys.right = keys.boost = false;
+      steering = false; pointerBoost = false;
       rocket.hidden = false;
       if (gameover) { gameover.hidden = true; gameover.classList.remove("in"); }
       if (toasts) toasts.innerHTML = "";
@@ -723,7 +737,6 @@
       try { audio(); if (actx && actx.state === "suspended") actx.resume(); } catch (e) { /* ignore */ }
       if (gcanvas) gcanvas.hidden = false;
       if (hud) hud.hidden = false;
-      if (dpad) { dpad.hidden = false; dpad.classList.add("is-on"); }
       document.documentElement.classList.add("flying");
       btn.setAttribute("aria-pressed", "true");
       updateHud(); render(); drawGame();
@@ -735,10 +748,10 @@
       if (!active) return;
       active = false;
       cancelAnimationFrame(raf);
-      keys.up = keys.down = keys.left = keys.right = keys.boost = keys.fire = false;
+      keys.up = keys.down = keys.left = keys.right = keys.boost = false;
+      steering = false; pointerBoost = false;
       rocket.classList.remove("is-boosting");
       rocket.hidden = true;
-      if (dpad) { dpad.hidden = true; dpad.classList.remove("is-on"); }
       if (gcanvas) { gcanvas.hidden = true; if (gctx) { gctx.setTransform(1, 0, 0, 1, 0, 0); gctx.clearRect(0, 0, gcanvas.width, gcanvas.height); } }
       if (hud) hud.hidden = true;
       if (gameover) { gameover.hidden = true; gameover.classList.remove("in"); }
@@ -763,7 +776,6 @@
     window.addEventListener("keydown", (e) => {
       if (e.key === "Escape" && active) { stop(); return; }
       if (!active) return;
-      if (e.code === "Space") { keys.fire = true; e.preventDefault(); return; }
       if (e.key === "Shift") { keys.boost = true; return; }
       const dir = KEYMAP[e.code];
       if (!dir) return;
@@ -771,31 +783,37 @@
       e.preventDefault();                // stop arrows from scrolling on their own
     });
     window.addEventListener("keyup", (e) => {
-      if (e.code === "Space") { keys.fire = false; return; }
       if (e.key === "Shift") keys.boost = false;
       const dir = KEYMAP[e.code];
       if (dir) keys[dir] = false;
     });
 
-    // click / tap to shoot (ignore clicks on UI chrome)
-    window.addEventListener("mousedown", (e) => {
-      if (!active || dead) return;
-      if (e.target.closest(".nav, .dpad, .gameover, button, a")) return;
-      tryShoot();
-    });
+    // click / tap in front of the ship to steer toward the pointer — held
+    // means keep steering, like slither.io — and a second press within the
+    // double-click/tap window engages boost for as long as it stays down.
+    // Works identically for mouse and touch. Ignore clicks on UI chrome.
+    const TAP_GAP_MS = 350, TAP_GAP_PX = 40;
+    function isChrome(el) { return el.closest && el.closest(".nav, .gameover, button, a"); }
 
-    // on-screen d-pad for touch
-    if (dpad) {
-      dpad.querySelectorAll(".dpad__btn").forEach((b) => {
-        const dir = b.getAttribute("data-dir");
-        const on = (e) => { e.preventDefault(); keys[dir] = true; };
-        const off = (e) => { e.preventDefault(); keys[dir] = false; };
-        b.addEventListener("pointerdown", on);
-        b.addEventListener("pointerup", off);
-        b.addEventListener("pointerleave", off);
-        b.addEventListener("pointercancel", off);
-      });
-    }
+    window.addEventListener("pointerdown", (e) => {
+      if (!active || dead || isChrome(e.target)) return;
+      const now = performance.now();
+      const isDouble = now - lastTapTime < TAP_GAP_MS &&
+        Math.hypot(e.clientX - lastTapX, e.clientY - lastTapY) < TAP_GAP_PX;
+      lastTapTime = now; lastTapX = e.clientX; lastTapY = e.clientY;
+      steering = true;
+      pointerBoost = isDouble;
+      targetX = e.clientX; targetY = e.clientY;
+      e.preventDefault();
+    }, { passive: false });
+    window.addEventListener("pointermove", (e) => {
+      if (!steering) return;
+      targetX = e.clientX; targetY = e.clientY;
+      e.preventDefault();
+    }, { passive: false });
+    function endSteer() { steering = false; pointerBoost = false; }
+    window.addEventListener("pointerup", endSteer);
+    window.addEventListener("pointercancel", endSteer);
 
     // keep things on screen / sized when the window changes
     window.addEventListener("resize", () => {

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <a href="#contact">Contact</a>
   </nav>
   <div class="nav__actions">
-    <button type="button" class="nav__fly" id="flyBtn" aria-pressed="false" aria-label="Fly a rocket and fight aliens" title="Fly &amp; fight: WASD/arrows to move, click or Space to shoot, Shift to boost">
+    <button type="button" class="nav__fly" id="flyBtn" aria-pressed="false" aria-label="Fly a rocket and fight aliens" title="Fly &amp; fight: click or tap in front of the ship to move, double-click/tap and hold to boost — the gun fires automatically while moving">
       <span class="nav__fly-ico" aria-hidden="true">🚀</span>
     </button>
     <a href="#contact" class="nav__cta">Available</a>
@@ -78,13 +78,6 @@
   <span class="rocket__flame" aria-hidden="true"></span>
 </div>
 
-
-<div class="dpad" id="dpad" hidden aria-hidden="true">
-  <button class="dpad__btn dpad__up"    data-dir="up">▲</button>
-  <button class="dpad__btn dpad__left"  data-dir="left">◀</button>
-  <button class="dpad__btn dpad__right" data-dir="right">▶</button>
-  <button class="dpad__btn dpad__down"  data-dir="down">▼</button>
-</div>
 
 <!-- ============ GAME (combat layer · HUD · achievements) ============ -->
 <canvas class="game-layer" id="gameLayer" hidden aria-hidden="true"></canvas>


### PR DESCRIPTION
## Summary
- Replaces the on-screen d-pad with slither.io-style pointer steering: click or tap in front of the rocket to steer toward the pointer, and it keeps steering for as long as the press is held. Works identically for mouse and touch via the Pointer Events API.
- A second click/tap within the double-click window (350ms, 40px) engages boost for as long as it's held.
- The gun now fires automatically whenever the rocket is moving (speed above a small threshold) — no separate fire button/key, no more `keys.fire`/`isTouch` branch.
- Removed the `#dpad` markup, its JS wiring, and all its CSS. Added `touch-action: none` while flying so native touch scrolling doesn't fight the new pointer-based steering (the game already drives page scroll programmatically).
- Kept WASD/arrow keys and Shift-boost as an optional fallback on desktop; Escape still exits.
- Updated the fly button's tooltip to describe the new controls.

## Test plan
- [x] `node --check assets/js/main.js`
- [x] Served the site locally and drove it with headless Chromium (Playwright): confirmed `#dpad` no longer exists in the DOM, clicking/tapping in front of the rocket steers it toward the pointer, double-click-and-hold applies the `is-boosting` class, and the gun auto-fires (~10 shots in 1.5s of sustained movement) while moving but stops almost immediately once idle.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01P858PYueLdTBNzuFvGYLW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01P858PYueLdTBNzuFvGYLW8)_