### PR TITLE
Stop mobile drag-to-steer from scrolling the page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -40,7 +40,7 @@
 
 html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; background: #000; }
 html.flying { scroll-behavior: auto; touch-action: none; overscroll-behavior: none; }
-html.flying body { user-select: none; -webkit-user-select: none; cursor: crosshair; }
+html.flying body { user-select: none; -webkit-user-select: none; cursor: crosshair; touch-action: none; }
 
 body {
   font-family: var(--f-body);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -861,6 +861,12 @@
     window.addEventListener("pointermove", (e) => {
       if (aim.on) { aim.x = e.clientX; aim.y = e.clientY; }
     }, { passive: true });
+    // touch-action:none on the root doesn't reliably stop the *document* pan
+    // on mobile Safari/Chrome — dragging to steer would still scroll the page.
+    // A non-passive touchmove preventDefault is the only dependable way.
+    window.addEventListener("touchmove", (e) => {
+      if (active && !e.target.closest(".gameover")) e.preventDefault();
+    }, { passive: false });
     const aimOff = () => { aim.on = false; aim.boost = false; };
     window.addEventListener("pointerup", aimOff);
     window.addEventListener("pointercancel", aimOff);


### PR DESCRIPTION
## What

Dragging a thumb to steer in flight mode also panned the page on mobile — the browser's native scroll gesture fought the game's camera. `touch-action: none` on the root element is not reliably honored for the *document* pan gesture on mobile Safari/Chrome, so this adds the dependable fix: a non-passive `touchmove` listener that calls `preventDefault()` while flying (game-over panel exempt so it can still scroll on tiny screens). Also mirrors `touch-action: none` onto the body for good measure.

Normal page scrolling is untouched when not flying.

## Testing

Headless (Playwright, 390×720 touch): synthetic cancelable `touchmove` is not prevented before flight (page scrolls normally) and is prevented during flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)