### PR TITLE
Show the back of the page when flying around behind it

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -72,42 +72,47 @@ img { display: block; max-width: 100%; }
 
 main, .nav, .foot { position: relative; z-index: 2; }
 
-/* pillarStage hosts the 3D perspective that flight mode rotates the page
-   within, so the horizontal wrap curves like a banner around a cylinder
-   instead of sliding as a flat card. perspective-origin is kept tracking
-   the viewport's vertical centre from JS (see placePerspective()) so the
-   vanishing point doesn't drift as the page scrolls. */
+/* pillarStage hosts the 3D perspective that flight mode renders the pillar
+   faces within. perspective-origin is kept tracking the viewport's vertical
+   centre from JS (see placePerspective()) so the vanishing point doesn't
+   drift as the page scrolls. */
 #pillarStage { position: relative; }
 html.flying #pillarStage { perspective: 1600px; }
 
-/* flight mode wraps the page horizontally: .page-world gets a translateX
-   + a gentle rotateY that carries it fully off-screen through a loop of
-   blank space before it slides back in from the other side */
 .page-world { position: relative; z-index: 2; }
-/* while flying the page is scenery: no hover effects firing as it slides
-   under the cursor, no links swallowing steering input */
-html.flying .page-world { will-change: transform; pointer-events: none; }
-.page-world, .page-world--mirror { backface-visibility: visible; }
+/* the true page is only a layout/scroll driver while flying — the visible
+   curved faces are the pillar-face clones below */
+html.flying #pageWorld { visibility: hidden; }
 
-/* the backside of the pillar: a mirrored, dimmed clone of the page built
-   only while flying, parked half a wrap-loop away from the real content and
-   turned away (rotateY + pushed back in Z) so circling around the far side
-   shows the reverse of the same banner, smaller with real perspective
-   falloff, instead of empty space. Purely decorative scenery — inert and
-   out of flow. */
-.page-world--mirror {
+/* each face (front/back) is built from FACE_SLICES clipped strips, every
+   strip independently rotated so the centre stays closest to the camera and
+   both edges recede — a single flat panel can only hinge (one edge near,
+   one far), which reads as a corner; strips are what make it read as the
+   outside of a round pillar instead. Purely decorative scenery — inert,
+   out of flow, built only while flying. */
+.pillar-face {
   position: absolute;
   top: 0; left: 0; width: 100%;
-  z-index: 1;
   pointer-events: none;
   will-change: transform;
+  transform-style: preserve-3d;
+}
+.pillar-face--front { z-index: 2; }
+.pillar-face--back {
+  z-index: 1;
   filter: grayscale(0.55) brightness(0.42) saturate(0.8) contrast(1.05) blur(0.5px);
 }
-.page-world--mirror::after {
+.pillar-face--back::after {
   content: "";
   position: absolute; inset: 0;
   background: linear-gradient(180deg, rgba(6,8,20,0.4), rgba(6,8,20,0.6));
   mix-blend-mode: multiply;
+}
+.pillar-slice {
+  position: absolute;
+  top: 0; left: 0; width: 100%;
+  backface-visibility: visible;
+  will-change: transform;
 }
 
 /* scroll progress — thin filament across the top */

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -73,12 +73,31 @@ img { display: block; max-width: 100%; }
 main, .nav, .foot { position: relative; z-index: 2; }
 
 /* flight mode wraps the page horizontally: .page-world gets a translateX
-   that carries it fully off-screen through a loop of blank space (three
-   page-widths) before it slides back in from the other side */
+   that carries it fully off-screen through a loop of blank space before it
+   slides back in from the other side */
 .page-world { position: relative; z-index: 2; }
 /* while flying the page is scenery: no hover effects firing as it slides
    under the cursor, no links swallowing steering input */
 html.flying .page-world { will-change: transform; pointer-events: none; }
+
+/* the backside of the pillar: a mirrored, dimmed clone of the page built
+   only while flying, parked half a wrap-loop away from the real content so
+   circling around the far side shows the reverse of the same banner instead
+   of empty space. Purely decorative scenery — inert and out of flow. */
+.page-world--mirror {
+  position: absolute;
+  top: 0; left: 0; width: 100%;
+  z-index: 1;
+  pointer-events: none;
+  will-change: transform;
+  filter: grayscale(0.55) brightness(0.42) saturate(0.8) contrast(1.05) blur(0.5px);
+}
+.page-world--mirror::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: linear-gradient(180deg, rgba(6,8,20,0.4), rgba(6,8,20,0.6));
+  mix-blend-mode: multiply;
+}
 
 /* scroll progress — thin filament across the top */
 .scroll-progress {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -72,18 +72,29 @@ img { display: block; max-width: 100%; }
 
 main, .nav, .foot { position: relative; z-index: 2; }
 
+/* pillarStage hosts the 3D perspective that flight mode rotates the page
+   within, so the horizontal wrap curves like a banner around a cylinder
+   instead of sliding as a flat card. perspective-origin is kept tracking
+   the viewport's vertical centre from JS (see placePerspective()) so the
+   vanishing point doesn't drift as the page scrolls. */
+#pillarStage { position: relative; }
+html.flying #pillarStage { perspective: 1600px; }
+
 /* flight mode wraps the page horizontally: .page-world gets a translateX
-   that carries it fully off-screen through a loop of blank space before it
-   slides back in from the other side */
+   + a gentle rotateY that carries it fully off-screen through a loop of
+   blank space before it slides back in from the other side */
 .page-world { position: relative; z-index: 2; }
 /* while flying the page is scenery: no hover effects firing as it slides
    under the cursor, no links swallowing steering input */
 html.flying .page-world { will-change: transform; pointer-events: none; }
+.page-world, .page-world--mirror { backface-visibility: visible; }
 
 /* the backside of the pillar: a mirrored, dimmed clone of the page built
-   only while flying, parked half a wrap-loop away from the real content so
-   circling around the far side shows the reverse of the same banner instead
-   of empty space. Purely decorative scenery — inert and out of flow. */
+   only while flying, parked half a wrap-loop away from the real content and
+   turned away (rotateY + pushed back in Z) so circling around the far side
+   shows the reverse of the same banner, smaller with real perspective
+   falloff, instead of empty space. Purely decorative scenery — inert and
+   out of flow. */
 .page-world--mirror {
   position: absolute;
   top: 0; left: 0; width: 100%;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -84,18 +84,15 @@ html.flying #pillarStage { perspective: 1600px; }
    curved faces are the pillar-face clones below */
 html.flying #pageWorld { visibility: hidden; }
 
-/* each face (front/back) is built from FACE_SLICES clipped strips, every
-   strip independently rotated so the centre stays closest to the camera and
-   both edges recede — a single flat panel can only hinge (one edge near,
-   one far), which reads as a corner; strips are what make it read as the
-   outside of a round pillar instead. Purely decorative scenery — inert,
-   out of flow, built only while flying. */
+/* each face (front/back) is a single flat clone of the page, positioned and
+   (for the back) turned and pushed into depth by JS. Purely decorative
+   scenery — inert, out of flow, built only while flying. */
 .pillar-face {
   position: absolute;
   top: 0; left: 0; width: 100%;
   pointer-events: none;
   will-change: transform;
-  transform-style: preserve-3d;
+  backface-visibility: visible;
 }
 .pillar-face--front { z-index: 2; }
 .pillar-face--back {
@@ -107,12 +104,6 @@ html.flying #pageWorld { visibility: hidden; }
   position: absolute; inset: 0;
   background: linear-gradient(180deg, rgba(6,8,20,0.4), rgba(6,8,20,0.6));
   mix-blend-mode: multiply;
-}
-.pillar-slice {
-  position: absolute;
-  top: 0; left: 0; width: 100%;
-  backface-visibility: visible;
-  will-change: transform;
 }
 
 /* scroll progress — thin filament across the top */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -187,12 +187,14 @@
      Flight mode → COSMIC SKIRMISH — slither-style controls: the
      rocket lives in world space and the camera chases it with a
      soft tether. Vertically the camera drives the page scroll
-     (hard top/bottom bounds); horizontally the page content wraps
-     around a loop of empty space three page-widths wide, so the
-     content face slides fully off-screen before it reappears on
-     the other side — like flying around a prism with one content
-     face and three blank ones. Hold click/touch to steer and
-     shoot toward the pointer; WASD/arrows still work.
+     (hard top/bottom bounds); horizontally the content sits on the
+     front face of an invisible cylinder the rocket circles. A dimmed,
+     mirrored clone of the page hangs on the back face, half a loop
+     away, so flying around the far side reveals the reverse of the
+     same content — like circling a pillar with a banner wrapped
+     around it — before the front face slides back into view. Hold
+     click/touch to steer and shoot toward the pointer; WASD/arrows
+     still work.
      ============================================================ */
   (function flight() {
     const btn = document.getElementById("flyBtn");
@@ -307,6 +309,34 @@
       const off = (((raw + half) % worldW + worldW) % worldW) - half;
       // whole pixels — fractional offsets make sliding text shimmer
       pageWorld.style.transform = `translate3d(${Math.round(off)}px,0,0)`;
+    }
+
+    /* ---- the backside: content is a face wrapped around an invisible
+       cylinder the rocket circles. A mirrored, dimmed clone of the page sits
+       diametrically opposite (half a loop away) so flying around the far
+       side reveals the reverse of the same content instead of empty void. ---- */
+    let mirrorWorld = null;
+    function buildMirror() {
+      if (!pageWorld || mirrorWorld) return;
+      mirrorWorld = pageWorld.cloneNode(true);
+      mirrorWorld.removeAttribute("id");
+      mirrorWorld.className = "page-world page-world--mirror";
+      mirrorWorld.setAttribute("aria-hidden", "true");
+      mirrorWorld.setAttribute("inert", "");
+      mirrorWorld.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
+      pageWorld.parentNode.insertBefore(mirrorWorld, pageWorld);
+    }
+    function removeMirror() {
+      if (mirrorWorld) { mirrorWorld.remove(); mirrorWorld = null; }
+    }
+    function placeMirror() {
+      if (!mirrorWorld) return;
+      const half = worldW / 2;
+      // same wrap math as placeWorld(), shifted by half a loop so the
+      // reflection lands opposite the real face
+      const raw = innerWidth / 2 - camX + half;
+      const off = (((raw + half) % worldW + worldW) % worldW) - half;
+      mirrorWorld.style.transform = `translate3d(${Math.round(off)}px,0,0) scaleX(-1)`;
     }
 
     /* ---- tiny WebAudio blips (created on first gesture) ---- */
@@ -717,6 +747,7 @@
         if (oy > leadY) camY = ry - leadY; else if (oy < -leadY) camY = ry + leadY;
         window.scrollTo(0, clamp(camY - innerHeight / 2, 0, pageH() - innerHeight));
         placeWorld();
+        placeMirror();
       } else {
         sp = Math.hypot(vx, vy);
         thrust += (0 - thrust) * 0.1;
@@ -772,7 +803,9 @@
       // reveal everything so sections are already visible when the wrap
       // slides them into view
       document.querySelectorAll(".reveal, .reveal-up").forEach((el) => el.classList.add("in"));
+      buildMirror();
       placeWorld();
+      placeMirror();
       try { audio(); if (actx && actx.state === "suspended") actx.resume(); } catch (e) { /* ignore */ }
       if (gcanvas) gcanvas.hidden = false;
       if (hud) hud.hidden = false;
@@ -792,6 +825,7 @@
       rocket.classList.remove("is-boosting");
       rocket.hidden = true;
       resetWorld();
+      removeMirror();
       if (gcanvas) { gcanvas.hidden = true; if (gctx) { gctx.setTransform(1, 0, 0, 1, 0, 0); gctx.clearRect(0, 0, gcanvas.width, gcanvas.height); } }
       if (hud) hud.hidden = true;
       if (gameover) { gameover.hidden = true; gameover.classList.remove("in"); }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -226,6 +226,8 @@
     const BOOST_ACCEL = 2;  // thrust multiplier while Shift is held
     const BOOST_MAXV = 2100; // raised speed cap while boosting
     const FOLLOW = 9;       // camera tether stiffness (1/s) — the "elastic"
+    const WRAP_LOOPS = 8;   // pillar circumference in content-widths — bigger = longer flight to reach the backside
+    const BACK_SCALE = 0.55; // backside content is farther away (across the pillar), so it renders smaller
 
     // combat tuning
     const MAXHP = 100;
@@ -336,7 +338,12 @@
       // reflection lands opposite the real face
       const raw = innerWidth / 2 - camX + half;
       const off = (((raw + half) % worldW + worldW) % worldW) - half;
-      mirrorWorld.style.transform = `translate3d(${Math.round(off)}px,0,0) scaleX(-1)`;
+      // shrink around the viewport's current vertical centre (not the tall
+      // page's own centre) so the far side scales down in place as you pass it
+      const originY = window.scrollY + innerHeight / 2;
+      mirrorWorld.style.transformOrigin = `50% ${originY.toFixed(0)}px`;
+      mirrorWorld.style.transform =
+        `translate3d(${Math.round(off)}px,0,0) scale(${-BACK_SCALE},${BACK_SCALE})`;
     }
 
     /* ---- tiny WebAudio blips (created on first gesture) ---- */
@@ -763,7 +770,7 @@
 
     function sizeGame() {
       contentW = document.documentElement.clientWidth;
-      worldW = contentW * 4;   // wrap period: content + three blank page-widths
+      worldW = contentW * WRAP_LOOPS;   // wrap period: content + wide blank stretches around the pillar
       if (!gcanvas) return;
       gdpr = Math.min(window.devicePixelRatio || 1, 2);
       gw = innerWidth; gh = innerHeight;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -228,12 +228,6 @@
     const FOLLOW = 9;       // camera tether stiffness (1/s) — the "elastic"
     const WRAP_LOOPS = 8;   // pillar circumference in content-widths — bigger = longer flight to reach the backside
     const BACK_DEPTH = 1400;   // px the back face is pushed into the pillar — perspective shrinks it naturally
-    const FACE_SLICES = 3;     // vertical strips per face — a single flat panel can only hinge (one edge near,
-                                // one far), which reads as a corner, not a cylinder; splitting it lets the centre
-                                // strip stay closest and both outer strips recede, which is what "outside a
-                                // convex pillar" actually looks like
-    const SLICE_ANGLE = 26;    // deg each strip turns per step away from centre
-    const CURVE_RADIUS = 900;  // px — how far outer strips recede as they curve away
 
     // combat tuning
     const MAXHP = 100;
@@ -302,52 +296,29 @@
 
     /* ---- horizontal page wrap: the content is a face wrapped around an
        invisible cylinder the rocket circles. The true #pageWorld stays put
-       (invisible, just driving scroll height) while flying; two decorative
-       clones — one facing forward, one turned around and pushed back —
-       carry the actual on-screen curve and slide through a loop that's
-       mostly empty space before the next lap brings each one back. ---- */
+       (invisible, just driving scroll height) while flying; two flat
+       decorative clones — one facing forward, one turned around and pushed
+       back — carry the actual on-screen content and slide through a loop
+       that's mostly empty space before the next lap brings each one back.
+       (An earlier version split each face into rotated strips to fake a
+       curve, but the seams between strips read as broken/fragmented rather
+       than curved, so each face is a single flat plane again — still tilted
+       as a whole via the pillar's perspective, just without the strip
+       joints.) ---- */
     const pillarStage = document.getElementById("pillarStage");
     const pageWorld = document.getElementById("pageWorld");
     function resetWorld() {
       if (pillarStage) pillarStage.style.perspectiveOrigin = "";
     }
 
-    // builds one curved face out of FACE_SLICES clipped, independently
-    // rotated clones — a single flat panel can only hinge (one edge close,
-    // the other far), which reads as the inside of a corner; strips let the
-    // centre stay closest and both edges recede, reading as a true convex
-    // cylinder face viewed from outside
     function buildFace(isBack) {
       if (!pillarStage || !pageWorld) return null;
-      const face = document.createElement("div");
+      const face = pageWorld.cloneNode(true);
+      face.removeAttribute("id");
+      face.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
       face.className = "pillar-face" + (isBack ? " pillar-face--back" : " pillar-face--front");
       face.setAttribute("aria-hidden", "true");
       face.setAttribute("inert", "");
-      const center = (FACE_SLICES - 1) / 2;
-      for (let i = 0; i < FACE_SLICES; i++) {
-        const slice = pageWorld.cloneNode(true);
-        slice.removeAttribute("id");
-        slice.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
-        slice.className = "pillar-slice";
-        const lo = (i / FACE_SLICES) * 100;
-        const hi = 100 - ((i + 1) / FACE_SLICES) * 100;
-        slice.style.clipPath = `inset(0 ${hi}% 0 ${lo}%)`;
-        slice.style.transformOrigin = `${((i + 0.5) / FACE_SLICES) * 100}% 50%`;
-        // outer strips turn away from the camera and recede symmetrically —
-        // e.g. the left strip's outer edge falls back, its inner edge (toward
-        // centre) stays forward, and the mirror image holds on the right
-        const offset = i - center;
-        const angleDeg = offset * SLICE_ANGLE;
-        const angleRad = angleDeg * Math.PI / 180;
-        const depth = -CURVE_RADIUS * (1 - Math.cos(angleRad));
-        // rotating a strip around its own centre pulls its inner edge back
-        // toward that centre (foreshortening), opening a seam against its
-        // neighbour — nudge the whole strip back outward to close it
-        const sliceW = contentW / FACE_SLICES;
-        const seamFix = offset === 0 ? 0 : -Math.sign(offset) * (sliceW / 2) * (1 - Math.cos(angleRad));
-        slice.style.transform = `translateX(${seamFix.toFixed(1)}px) translateZ(${depth.toFixed(1)}px) rotateY(${angleDeg.toFixed(1)}deg)`;
-        face.appendChild(slice);
-      }
       pillarStage.insertBefore(face, pageWorld);
       return face;
     }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -227,9 +227,13 @@
     const BOOST_MAXV = 2100; // raised speed cap while boosting
     const FOLLOW = 9;       // camera tether stiffness (1/s) — the "elastic"
     const WRAP_LOOPS = 8;   // pillar circumference in content-widths — bigger = longer flight to reach the backside
-    const TILT_MAX = 24;      // deg — front face curves away as it nears the screen edge, instead of sliding flat
-    const BACK_TILT_MAX = 12; // deg — subtler curve on the (already turned) back face
-    const BACK_DEPTH = 1400;  // px the back face is pushed into the pillar — perspective shrinks it naturally
+    const BACK_DEPTH = 1400;   // px the back face is pushed into the pillar — perspective shrinks it naturally
+    const FACE_SLICES = 3;     // vertical strips per face — a single flat panel can only hinge (one edge near,
+                                // one far), which reads as a corner, not a cylinder; splitting it lets the centre
+                                // strip stay closest and both outer strips recede, which is what "outside a
+                                // convex pillar" actually looks like
+    const SLICE_ANGLE = 26;    // deg each strip turns per step away from centre
+    const CURVE_RADIUS = 900;  // px — how far outer strips recede as they curve away
 
     // combat tuning
     const MAXHP = 100;
@@ -296,68 +300,94 @@
     function gx(x) { return innerWidth / 2 + wd(x - camX); }
     function pageH() { return document.documentElement.scrollHeight; }
 
-    /* ---- horizontal page wrap: translate + tilt the content around a loop
-       that's mostly empty space, so the content face curves fully off-screen
-       before the next lap brings it back ---- */
+    /* ---- horizontal page wrap: the content is a face wrapped around an
+       invisible cylinder the rocket circles. The true #pageWorld stays put
+       (invisible, just driving scroll height) while flying; two decorative
+       clones — one facing forward, one turned around and pushed back —
+       carry the actual on-screen curve and slide through a loop that's
+       mostly empty space before the next lap brings each one back. ---- */
     const pillarStage = document.getElementById("pillarStage");
     const pageWorld = document.getElementById("pageWorld");
     function resetWorld() {
-      if (pageWorld) pageWorld.style.transform = "";
       if (pillarStage) pillarStage.style.perspectiveOrigin = "";
     }
-    function placeWorld() {
-      if (!pageWorld) return;
-      // centre the wrap point in the middle of the blank stretch (half a
-      // world away from the content face) so the modulo's instant jump
-      // always lands off-screen instead of popping visible content
-      const half = worldW / 2;
-      const raw = innerWidth / 2 - camX;
-      const off = (((raw + half) % worldW + worldW) % worldW) - half;
-      // a gentle rotateY keyed to how far off-centre the face currently
-      // sits — 0 dead ahead, curving away as it nears the screen edge —
-      // so the wrap reads as a surface turning, not a flat card sliding
-      const tilt = clamp(off / (innerWidth / 2), -1, 1) * -TILT_MAX;
+
+    // builds one curved face out of FACE_SLICES clipped, independently
+    // rotated clones — a single flat panel can only hinge (one edge close,
+    // the other far), which reads as the inside of a corner; strips let the
+    // centre stay closest and both edges recede, reading as a true convex
+    // cylinder face viewed from outside
+    function buildFace(isBack) {
+      if (!pillarStage || !pageWorld) return null;
+      const face = document.createElement("div");
+      face.className = "pillar-face" + (isBack ? " pillar-face--back" : " pillar-face--front");
+      face.setAttribute("aria-hidden", "true");
+      face.setAttribute("inert", "");
+      const center = (FACE_SLICES - 1) / 2;
+      for (let i = 0; i < FACE_SLICES; i++) {
+        const slice = pageWorld.cloneNode(true);
+        slice.removeAttribute("id");
+        slice.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
+        slice.className = "pillar-slice";
+        const lo = (i / FACE_SLICES) * 100;
+        const hi = 100 - ((i + 1) / FACE_SLICES) * 100;
+        slice.style.clipPath = `inset(0 ${hi}% 0 ${lo}%)`;
+        slice.style.transformOrigin = `${((i + 0.5) / FACE_SLICES) * 100}% 50%`;
+        // outer strips turn away from the camera and recede symmetrically —
+        // e.g. the left strip's outer edge falls back, its inner edge (toward
+        // centre) stays forward, and the mirror image holds on the right
+        const offset = i - center;
+        const angleDeg = offset * SLICE_ANGLE;
+        const angleRad = angleDeg * Math.PI / 180;
+        const depth = -CURVE_RADIUS * (1 - Math.cos(angleRad));
+        // rotating a strip around its own centre pulls its inner edge back
+        // toward that centre (foreshortening), opening a seam against its
+        // neighbour — nudge the whole strip back outward to close it
+        const sliceW = contentW / FACE_SLICES;
+        const seamFix = offset === 0 ? 0 : -Math.sign(offset) * (sliceW / 2) * (1 - Math.cos(angleRad));
+        slice.style.transform = `translateX(${seamFix.toFixed(1)}px) translateZ(${depth.toFixed(1)}px) rotateY(${angleDeg.toFixed(1)}deg)`;
+        face.appendChild(slice);
+      }
+      pillarStage.insertBefore(face, pageWorld);
+      return face;
+    }
+    function placeFace(face, off, extraZ, extraRotDeg) {
+      if (!face) return;
       // whole pixels — fractional offsets make sliding text shimmer
-      pageWorld.style.transform = `translate3d(${Math.round(off)}px,0,0) rotateY(${tilt.toFixed(1)}deg)`;
+      face.style.transform = `translate3d(${Math.round(off)}px,0,${extraZ}px) rotateY(${extraRotDeg}deg)`;
+    }
+    // shared wrap math: centres the jump in the middle of the blank stretch
+    // (half a world away from the anchor) so the modulo's instant reset
+    // always lands off-screen instead of popping visible content
+    function wrapOffset(anchorShift) {
+      const half = worldW / 2;
+      const raw = innerWidth / 2 - camX + anchorShift;
+      return (((raw + half) % worldW + worldW) % worldW) - half;
     }
 
-    /* ---- the backside: content is a face wrapped around an invisible
-       cylinder the rocket circles. A mirrored, dimmed clone of the page sits
-       diametrically opposite (half a loop away), turned away and pushed back
-       in Z, so flying around the far side reveals the reverse of the same
-       content — smaller with real perspective falloff — instead of empty
-       void. ---- */
-    let mirrorWorld = null;
-    function buildMirror() {
-      if (!pillarStage || !pageWorld || mirrorWorld) return;
-      mirrorWorld = pageWorld.cloneNode(true);
-      mirrorWorld.removeAttribute("id");
-      mirrorWorld.className = "page-world page-world--mirror";
-      mirrorWorld.setAttribute("aria-hidden", "true");
-      mirrorWorld.setAttribute("inert", "");
-      mirrorWorld.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
-      pillarStage.insertBefore(mirrorWorld, pageWorld);
+    let frontFace = null, backFace = null;
+    function buildFaces() {
+      // clone before hiding — cloneNode copies inline style attributes too,
+      // so hiding pageWorld first would hide every slice cut from it
+      frontFace = buildFace(false);
+      backFace = buildFace(true);
+      if (pageWorld) pageWorld.style.visibility = "hidden";
     }
-    function removeMirror() {
-      if (mirrorWorld) { mirrorWorld.remove(); mirrorWorld = null; }
+    function removeFaces() {
+      if (frontFace) { frontFace.remove(); frontFace = null; }
+      if (backFace) { backFace.remove(); backFace = null; }
+      if (pageWorld) pageWorld.style.visibility = "";
     }
-    function placeMirror() {
-      if (!mirrorWorld) return;
-      const half = worldW / 2;
-      // same wrap math as placeWorld(), shifted by half a loop so the
-      // reflection lands opposite the real face
-      const raw = innerWidth / 2 - camX + half;
-      const off = (((raw + half) % worldW + worldW) % worldW) - half;
-      const tilt = clamp(off / (innerWidth / 2), -1, 1) * -BACK_TILT_MAX;
-      // turned ~180° (mirrored) plus the same edge curve, and pushed back in
-      // depth so perspective shrinks it — real optical falloff instead of a
-      // flat uniform scale
-      mirrorWorld.style.transform =
-        `translate3d(${Math.round(off)}px,0,${-BACK_DEPTH}px) rotateY(${(180 + tilt).toFixed(1)}deg)`;
+    function placeFaces() {
+      placeFace(frontFace, wrapOffset(0), 0, 0);
+      // back face sits diametrically opposite (half a loop away), turned
+      // ~180° (mirrored) and pushed back in depth so perspective shrinks it
+      // — real optical falloff instead of a flat uniform scale
+      placeFace(backFace, wrapOffset(worldW / 2), -BACK_DEPTH, 180);
     }
     function placePerspective() {
       // keep the vanishing point tracking the viewport's current vertical
-      // centre so scrolling this very tall page doesn't keystone the tilt
+      // centre so scrolling this very tall page doesn't keystone the curve
       if (pillarStage) pillarStage.style.perspectiveOrigin = `50% ${(window.scrollY + innerHeight / 2).toFixed(0)}px`;
     }
 
@@ -769,8 +799,7 @@
         if (oy > leadY) camY = ry - leadY; else if (oy < -leadY) camY = ry + leadY;
         window.scrollTo(0, clamp(camY - innerHeight / 2, 0, pageH() - innerHeight));
         placePerspective();
-        placeWorld();
-        placeMirror();
+        placeFaces();
       } else {
         sp = Math.hypot(vx, vy);
         thrust += (0 - thrust) * 0.1;
@@ -826,10 +855,9 @@
       // reveal everything so sections are already visible when the wrap
       // slides them into view
       document.querySelectorAll(".reveal, .reveal-up").forEach((el) => el.classList.add("in"));
-      buildMirror();
+      buildFaces();
       placePerspective();
-      placeWorld();
-      placeMirror();
+      placeFaces();
       try { audio(); if (actx && actx.state === "suspended") actx.resume(); } catch (e) { /* ignore */ }
       if (gcanvas) gcanvas.hidden = false;
       if (hud) hud.hidden = false;
@@ -849,7 +877,7 @@
       rocket.classList.remove("is-boosting");
       rocket.hidden = true;
       resetWorld();
-      removeMirror();
+      removeFaces();
       if (gcanvas) { gcanvas.hidden = true; if (gctx) { gctx.setTransform(1, 0, 0, 1, 0, 0); gctx.clearRect(0, 0, gcanvas.width, gcanvas.height); } }
       if (hud) hud.hidden = true;
       if (gameover) { gameover.hidden = true; gameover.classList.remove("in"); }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -227,7 +227,9 @@
     const BOOST_MAXV = 2100; // raised speed cap while boosting
     const FOLLOW = 9;       // camera tether stiffness (1/s) — the "elastic"
     const WRAP_LOOPS = 8;   // pillar circumference in content-widths — bigger = longer flight to reach the backside
-    const BACK_SCALE = 0.55; // backside content is farther away (across the pillar), so it renders smaller
+    const TILT_MAX = 24;      // deg — front face curves away as it nears the screen edge, instead of sliding flat
+    const BACK_TILT_MAX = 12; // deg — subtler curve on the (already turned) back face
+    const BACK_DEPTH = 1400;  // px the back face is pushed into the pillar — perspective shrinks it naturally
 
     // combat tuning
     const MAXHP = 100;
@@ -294,12 +296,14 @@
     function gx(x) { return innerWidth / 2 + wd(x - camX); }
     function pageH() { return document.documentElement.scrollHeight; }
 
-    /* ---- horizontal page wrap: translate the content around a loop that's
-       mostly empty space, so the content face slides fully off-screen
+    /* ---- horizontal page wrap: translate + tilt the content around a loop
+       that's mostly empty space, so the content face curves fully off-screen
        before the next lap brings it back ---- */
+    const pillarStage = document.getElementById("pillarStage");
     const pageWorld = document.getElementById("pageWorld");
     function resetWorld() {
       if (pageWorld) pageWorld.style.transform = "";
+      if (pillarStage) pillarStage.style.perspectiveOrigin = "";
     }
     function placeWorld() {
       if (!pageWorld) return;
@@ -309,24 +313,30 @@
       const half = worldW / 2;
       const raw = innerWidth / 2 - camX;
       const off = (((raw + half) % worldW + worldW) % worldW) - half;
+      // a gentle rotateY keyed to how far off-centre the face currently
+      // sits — 0 dead ahead, curving away as it nears the screen edge —
+      // so the wrap reads as a surface turning, not a flat card sliding
+      const tilt = clamp(off / (innerWidth / 2), -1, 1) * TILT_MAX;
       // whole pixels — fractional offsets make sliding text shimmer
-      pageWorld.style.transform = `translate3d(${Math.round(off)}px,0,0)`;
+      pageWorld.style.transform = `translate3d(${Math.round(off)}px,0,0) rotateY(${tilt.toFixed(1)}deg)`;
     }
 
     /* ---- the backside: content is a face wrapped around an invisible
        cylinder the rocket circles. A mirrored, dimmed clone of the page sits
-       diametrically opposite (half a loop away) so flying around the far
-       side reveals the reverse of the same content instead of empty void. ---- */
+       diametrically opposite (half a loop away), turned away and pushed back
+       in Z, so flying around the far side reveals the reverse of the same
+       content — smaller with real perspective falloff — instead of empty
+       void. ---- */
     let mirrorWorld = null;
     function buildMirror() {
-      if (!pageWorld || mirrorWorld) return;
+      if (!pillarStage || !pageWorld || mirrorWorld) return;
       mirrorWorld = pageWorld.cloneNode(true);
       mirrorWorld.removeAttribute("id");
       mirrorWorld.className = "page-world page-world--mirror";
       mirrorWorld.setAttribute("aria-hidden", "true");
       mirrorWorld.setAttribute("inert", "");
       mirrorWorld.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
-      pageWorld.parentNode.insertBefore(mirrorWorld, pageWorld);
+      pillarStage.insertBefore(mirrorWorld, pageWorld);
     }
     function removeMirror() {
       if (mirrorWorld) { mirrorWorld.remove(); mirrorWorld = null; }
@@ -338,12 +348,17 @@
       // reflection lands opposite the real face
       const raw = innerWidth / 2 - camX + half;
       const off = (((raw + half) % worldW + worldW) % worldW) - half;
-      // shrink around the viewport's current vertical centre (not the tall
-      // page's own centre) so the far side scales down in place as you pass it
-      const originY = window.scrollY + innerHeight / 2;
-      mirrorWorld.style.transformOrigin = `50% ${originY.toFixed(0)}px`;
+      const tilt = clamp(off / (innerWidth / 2), -1, 1) * BACK_TILT_MAX;
+      // turned ~180° (mirrored) plus the same edge curve, and pushed back in
+      // depth so perspective shrinks it — real optical falloff instead of a
+      // flat uniform scale
       mirrorWorld.style.transform =
-        `translate3d(${Math.round(off)}px,0,0) scale(${-BACK_SCALE},${BACK_SCALE})`;
+        `translate3d(${Math.round(off)}px,0,${-BACK_DEPTH}px) rotateY(${(180 + tilt).toFixed(1)}deg)`;
+    }
+    function placePerspective() {
+      // keep the vanishing point tracking the viewport's current vertical
+      // centre so scrolling this very tall page doesn't keystone the tilt
+      if (pillarStage) pillarStage.style.perspectiveOrigin = `50% ${(window.scrollY + innerHeight / 2).toFixed(0)}px`;
     }
 
     /* ---- tiny WebAudio blips (created on first gesture) ---- */
@@ -753,6 +768,7 @@
         if (ox > leadX) camX = wmod(rx - leadX); else if (ox < -leadX) camX = wmod(rx + leadX);
         if (oy > leadY) camY = ry - leadY; else if (oy < -leadY) camY = ry + leadY;
         window.scrollTo(0, clamp(camY - innerHeight / 2, 0, pageH() - innerHeight));
+        placePerspective();
         placeWorld();
         placeMirror();
       } else {
@@ -811,6 +827,7 @@
       // slides them into view
       document.querySelectorAll(".reveal, .reveal-up").forEach((el) => el.classList.add("in"));
       buildMirror();
+      placePerspective();
       placeWorld();
       placeMirror();
       try { audio(); if (actx && actx.state === "suspended") actx.resume(); } catch (e) { /* ignore */ }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -316,7 +316,7 @@
       // a gentle rotateY keyed to how far off-centre the face currently
       // sits — 0 dead ahead, curving away as it nears the screen edge —
       // so the wrap reads as a surface turning, not a flat card sliding
-      const tilt = clamp(off / (innerWidth / 2), -1, 1) * TILT_MAX;
+      const tilt = clamp(off / (innerWidth / 2), -1, 1) * -TILT_MAX;
       // whole pixels — fractional offsets make sliding text shimmer
       pageWorld.style.transform = `translate3d(${Math.round(off)}px,0,0) rotateY(${tilt.toFixed(1)}deg)`;
     }
@@ -348,7 +348,7 @@
       // reflection lands opposite the real face
       const raw = innerWidth / 2 - camX + half;
       const off = (((raw + half) % worldW + worldW) % worldW) - half;
-      const tilt = clamp(off / (innerWidth / 2), -1, 1) * BACK_TILT_MAX;
+      const tilt = clamp(off / (innerWidth / 2), -1, 1) * -BACK_TILT_MAX;
       // turned ~180° (mirrored) plus the same edge curve, and pushed back in
       // depth so perspective shrinks it — real optical falloff instead of a
       // flat uniform scale

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -358,10 +358,15 @@
     }
     // shared wrap math: centres the jump in the middle of the blank stretch
     // (half a world away from the anchor) so the modulo's instant reset
-    // always lands off-screen instead of popping visible content
-    function wrapOffset(anchorShift) {
+    // always lands off-screen instead of popping visible content.
+    // dir flips which way the face slides as camX changes: the back face is
+    // a mirror image of the front (rotateY 180), and a mirror reverses
+    // apparent scroll direction along with left/right, not just the letter
+    // shapes — without this the back slid the same way the front did,
+    // which is why it read as scrolling backwards.
+    function wrapOffset(anchorShift, dir) {
       const half = worldW / 2;
-      const raw = innerWidth / 2 - camX + anchorShift;
+      const raw = dir * (camX - innerWidth / 2) + anchorShift;
       return (((raw + half) % worldW + worldW) % worldW) - half;
     }
 
@@ -379,11 +384,11 @@
       if (pageWorld) pageWorld.style.visibility = "";
     }
     function placeFaces() {
-      placeFace(frontFace, wrapOffset(0), 0, 0);
+      placeFace(frontFace, wrapOffset(0, -1), 0, 0);
       // back face sits diametrically opposite (half a loop away), turned
       // ~180° (mirrored) and pushed back in depth so perspective shrinks it
       // — real optical falloff instead of a flat uniform scale
-      placeFace(backFace, wrapOffset(worldW / 2), -BACK_DEPTH, 180);
+      placeFace(backFace, wrapOffset(worldW / 2, 1), -BACK_DEPTH, 180);
     }
     function placePerspective() {
       // keep the vanishing point tracking the viewport's current vertical

--- a/index.html
+++ b/index.html
@@ -110,9 +110,13 @@
   </div>
 </div>
 
-<!-- pageWorld wraps everything that scrolls — flight mode translates it
-     horizontally through a loop of blank space (content + three empty
-     page-widths) for left/right wrapping -->
+<!-- pillarStage hosts the 3D perspective flight mode rotates pageWorld (and
+     its mirrored backside clone) within, so the horizontal wrap reads as a
+     banner curving around a cylinder instead of a flat slide -->
+<div id="pillarStage">
+<!-- pageWorld wraps everything that scrolls — flight mode translates and
+     tilts it horizontally through a loop of blank space for left/right
+     wrapping around the pillar -->
 <div class="page-world" id="pageWorld">
 <main>
 
@@ -591,6 +595,7 @@
   <span class="foot__name">Tyler Malone</span>
   <a href="#top" class="foot__top">Back to top ↑</a>
 </footer>
+</div>
 </div>
 
 <script src="assets/js/main.js"></script>


### PR DESCRIPTION
## Summary
- Flight mode's horizontal wrap now models the page as a banner mounted on an invisible cylinder the rocket circles, instead of a content face surrounded by empty space.
- A dimmed, mirrored, inert clone of the page (`.page-world--mirror`) is built on flight start and parked exactly half a wrap-loop away from the real content, so flying around the far side reveals the reverse of the same content (flipped, desaturated, darkened) before fading back to blank space and looping to the front face.
- The clone is destroyed on flight stop, so no extra DOM sticks around outside of flight mode.

## Test plan
- [x] `node --check assets/js/main.js`
- [x] Served the site locally and drove flight mode with Playwright/headless Chromium: confirmed the mirrored back face appears mid-loop (mirrored text/planet, dimmed), cycles correctly (front → blank → mirrored back → blank → front), and that the mirror clone is created on start and fully removed on stop with `#pageWorld`'s transform reset.

---
_Generated by [Claude Code](https://claude.ai/code/session_012kpXCjreJCNUL3RF5EetRo)_