### PR TITLE
Add global leaderboards (time, kills, distance)

### DIFF
--- a/api/_check.mjs
+++ b/api/_check.mjs
@@ -1,0 +1,12 @@
+// Runnable self-check for the score sanity gate: `node api/_check.mjs`.
+// Underscore prefix keeps Vercel from routing this as an endpoint.
+import { sane } from "./score.mjs";
+import assert from "node:assert";
+
+assert.equal(sane(30, 20, 40000), true, "a plausible run passes");
+assert.equal(sane(0, 0, 0), false, "zero time rejected");
+assert.equal(sane(-5, 1, 1), false, "negative time rejected");
+assert.equal(sane(10, 999, 1000), false, "impossible kill count rejected");
+assert.equal(sane(10, 5, 9_999_999), false, "impossible distance rejected");
+assert.equal(sane(10, 40, 20000), true, "kills at the cap pass"); // 10*4+5=45 >= 40
+console.log("sanity gate ok");

--- a/api/_redis.mjs
+++ b/api/_redis.mjs
@@ -1,0 +1,20 @@
+// Tiny Upstash Redis REST client. No dependency — Upstash speaks HTTP.
+// Env vars are set automatically by the Vercel Upstash marketplace integration
+// (KV_* is the name Vercel's KV/Upstash integration uses; UPSTASH_* is the
+// direct-Upstash name). We accept either so it works however it's provisioned.
+const URL = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+const TOKEN = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+
+// Run an array of Redis commands as one pipeline. Returns [{result}|{error}, ...].
+export async function pipe(commands) {
+  if (!URL || !TOKEN) throw new Error("Redis env vars missing");
+  const r = await fetch(URL + "/pipeline", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify(commands),
+  });
+  if (!r.ok) throw new Error("Redis " + r.status);
+  return r.json();
+}
+
+export const BOARDS = ["time", "kills", "distance"];

--- a/api/leaderboard.mjs
+++ b/api/leaderboard.mjs
@@ -1,0 +1,24 @@
+import { pipe, BOARDS } from "./_redis.mjs";
+
+// GET /api/leaderboard -> { time:[{name,score}], kills:[...], distance:[...] }
+// Top 10 per board, highest first.
+export default async function handler(req, res) {
+  try {
+    const results = await pipe(
+      BOARDS.map((b) => ["ZRANGE", "lb:" + b, 0, 9, "REV", "WITHSCORES"])
+    );
+    const out = {};
+    BOARDS.forEach((b, i) => {
+      const flat = results[i].result || []; // [member, score, member, score, ...]
+      const rows = [];
+      for (let j = 0; j < flat.length; j += 2) {
+        rows.push({ name: String(flat[j]).split("#")[0], score: Number(flat[j + 1]) });
+      }
+      out[b] = rows;
+    });
+    res.setHeader("Cache-Control", "public, s-maxage=10");
+    res.status(200).json(out);
+  } catch (e) {
+    res.status(500).json({ error: "leaderboard unavailable" });
+  }
+}

--- a/api/score.mjs
+++ b/api/score.mjs
@@ -1,0 +1,38 @@
+import { pipe } from "./_redis.mjs";
+
+// ponytail: sanity caps only, not real anti-cheat. Client scores are forgeable;
+// these just reject physically-impossible direct POSTs. MAXV in the game is
+// 2100 px/s, so distance can't exceed 2100*time. Kills are gated by spawn rate.
+export function sane(time, kills, distance) {
+  if (!(time > 0) || time > 7200) return false;
+  if (!(kills >= 0) || kills > time * 4 + 5) return false;
+  if (!(distance >= 0) || distance > time * 2100 + 200) return false;
+  return true;
+}
+
+// POST /api/score { name, time, kills, distance }
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).end();
+  try {
+    const b = req.body || {};
+    const time = Number(b.time), kills = Number(b.kills), distance = Number(b.distance);
+    if ([time, kills, distance].some((n) => !Number.isFinite(n)) || !sane(time, kills, distance)) {
+      return res.status(400).json({ error: "invalid score" });
+    }
+    const name = String(b.name || "???").replace(/[^\w \-]/g, "").slice(0, 12).trim() || "???";
+    // Unique member per run so same-name runs don't overwrite each other.
+    const member = name + "#" + Math.random().toString(36).slice(2, 9);
+    // ZADD the run, then trim each board to its top 100 so storage stays bounded.
+    await pipe([
+      ["ZADD", "lb:time", time.toFixed(1), member],
+      ["ZADD", "lb:kills", String(Math.round(kills)), member],
+      ["ZADD", "lb:distance", String(Math.round(distance)), member],
+      ["ZREMRANGEBYRANK", "lb:time", 0, -101],
+      ["ZREMRANGEBYRANK", "lb:kills", 0, -101],
+      ["ZREMRANGEBYRANK", "lb:distance", 0, -101],
+    ]);
+    res.status(200).json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ error: "could not save score" });
+  }
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -330,6 +330,26 @@ html.flying #pageWorld { visibility: hidden; }
 .gostat span { font-size: .68rem; text-transform: uppercase; letter-spacing: .04em; color: var(--text-mute); }
 .gostat.is-best { border-color: rgba(233,201,135,0.5); box-shadow: 0 0 18px rgba(233,201,135,0.18); }
 .gostat em { display: block; color: var(--gold); font-style: normal; font-size: .58rem; margin-top: .15rem; letter-spacing: .08em; }
+.gameover__name { display: flex; align-items: center; justify-content: center; gap: .6rem; margin-bottom: 1.1rem; }
+.gameover__name label { font-size: .68rem; text-transform: uppercase; letter-spacing: .04em; color: var(--text-mute); }
+.gameover__name input {
+  width: 4.5rem; text-align: center; font-family: var(--f-mono); font-size: 1.1rem; letter-spacing: .12em;
+  text-transform: uppercase; padding: .25rem .3rem; border-radius: 6px; color: var(--star);
+  background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.15);
+}
+.gameover__name input:focus { outline: none; border-color: var(--cyan); box-shadow: 0 0 12px rgba(127,214,232,0.3); }
+.gameover__boards { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: .6rem; margin-bottom: 1.2rem; }
+.board { text-align: left; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; padding: .55rem .5rem; }
+.board h4 { font-size: .62rem; text-transform: uppercase; letter-spacing: .05em; color: var(--text-mute); margin: 0 0 .4rem; text-align: center; }
+.board ol { list-style: none; margin: 0; padding: 0; }
+.board li { display: flex; align-items: baseline; gap: .35rem; font-size: .68rem; padding: .1rem 0; color: var(--text-dim); }
+.board li.is-me { color: var(--gold); }
+.board__rank { width: 1.1rem; color: var(--text-mute); font-family: var(--f-mono); }
+.board__who { flex: 1; font-family: var(--f-mono); letter-spacing: .04em; overflow: hidden; text-overflow: ellipsis; }
+.board__val { font-family: var(--f-mono); color: var(--star); }
+.board li.is-me .board__val { color: var(--gold); }
+.board__empty, .board__err { color: var(--text-mute); font-size: .64rem; font-style: italic; }
+@media (max-width: 520px) { .gameover__boards { grid-template-columns: 1fr; } }
 .gameover__ach { margin-bottom: 1.3rem; }
 .gameover__ach-title {
   font-size: .72rem; text-transform: uppercase; letter-spacing: .05em;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -219,6 +219,8 @@
     const gameover = document.getElementById("gameover");
     const goSub = document.getElementById("goSub");
     const goStats = document.getElementById("goStats");
+    const goName = document.getElementById("goName");
+    const goBoards = document.getElementById("goBoards");
     const goAch = document.getElementById("goAch");
     const goAgain = document.getElementById("goAgain");
     const goClose = document.getElementById("goClose");
@@ -473,6 +475,54 @@
       } catch (e) { /* ignore */ }
     }
 
+    /* ---- global leaderboards ---- */
+    let runSubmitted = false; // one submit per run, even if initials are edited
+    function getName() {
+      try { return localStorage.getItem("tm_name") || ""; } catch (e) { return ""; }
+    }
+    async function submitScore() {
+      const name = getName();
+      if (runSubmitted || !name) return; // wait for initials on a first-ever run
+      runSubmitted = true;
+      try {
+        await fetch("/api/score", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, time: gTime, kills, distance: dist }),
+        });
+      } catch (e) { runSubmitted = false; } // let a later edit retry
+      loadBoards();
+    }
+    const BOARD_META = [
+      { key: "time", label: "Longest", fmt: (v) => v.toFixed(1) + "s" },
+      { key: "kills", label: "Most kills", fmt: (v) => String(Math.round(v)) },
+      { key: "distance", label: "Farthest", fmt: (v) => Math.round(v).toLocaleString() },
+    ];
+    async function loadBoards() {
+      if (!goBoards) return;
+      let data;
+      try { data = await (await fetch("/api/leaderboard")).json(); }
+      catch (e) { goBoards.innerHTML = `<div class="board__err">Leaderboards offline.</div>`; return; }
+      const mine = getName();
+      goBoards.innerHTML = BOARD_META.map((m) => {
+        const rows = (data[m.key] || []).slice(0, 10).map((r, i) =>
+          `<li${r.name === mine ? ' class="is-me"' : ""}><span class="board__rank">${i + 1}</span><span class="board__who">${r.name}</span><span class="board__val">${m.fmt(r.score)}</span></li>`
+        ).join("") || `<li class="board__empty">No scores yet</li>`;
+        return `<div class="board"><h4>${m.label}</h4><ol>${rows}</ol></div>`;
+      }).join("");
+    }
+    if (goName) {
+      goName.value = getName();
+      const commit = () => {
+        const v = goName.value.replace(/[^\w]/g, "").toUpperCase().slice(0, 3);
+        goName.value = v;
+        try { localStorage.setItem("tm_name", v); } catch (e) { /* ignore */ }
+        if (v) submitScore();
+      };
+      goName.addEventListener("change", commit);
+      goName.addEventListener("keydown", (e) => { if (e.key === "Enter") { commit(); goName.blur(); } });
+    }
+
     /* ---- achievements ---- */
     function checkAch() {
       const snap = {
@@ -542,6 +592,8 @@
           goAch.innerHTML = `<div class="gameover__ach-title">No medals this run — get back out there.</div>`;
         }
       }
+      submitScore(); // submits if initials are known; otherwise waits for entry
+      loadBoards();
       gameover.hidden = false;
       requestAnimationFrame(() => gameover.classList.add("in"));
     }
@@ -821,6 +873,7 @@
       gTime = 0; dist = 0; kills = 0; shots = 0; hits = 0; grazes = 0;
       noHit = 0; topSpeed = 0; dmgTaken = 0;
       reachedBottom = false; lowHpFlag = false; newBestTime = false; newBestKills = false;
+      runSubmitted = false;
       foes = []; pBullets = []; fBullets = []; parts = [];
       spawnT = 0.6; fireT = 0; shake = 0; shakeX = 0; shakeY = 0;
       unlocked.clear(); earned.length = 0;

--- a/index.html
+++ b/index.html
@@ -102,6 +102,11 @@
     <h2 class="gameover__title">You blew up</h2>
     <p class="gameover__sub" id="goSub"></p>
     <div class="gameover__stats" id="goStats"></div>
+    <div class="gameover__name">
+      <label for="goName">Your initials</label>
+      <input type="text" id="goName" maxlength="3" autocomplete="off" spellcheck="false" placeholder="???" aria-label="Your initials for the leaderboard">
+    </div>
+    <div class="gameover__boards" id="goBoards"></div>
     <div class="gameover__ach" id="goAch"></div>
     <div class="gameover__actions">
       <button type="button" class="gameover__btn gameover__btn--go" id="goAgain">Fly again</button>


### PR DESCRIPTION
## What

Three global high-score leaderboards on the rocket game's game-over overlay: **longest survival**, **most aliens killed**, and **farthest distance**. Separate boards (the game may change later), backed by Upstash Redis sorted sets.

## How it works

- **`api/score.mjs`** — `POST {name,time,kills,distance}`. Sanity-caps physically-impossible values (MAXV is 2100 px/s, so distance can't exceed 2100×time; kills gated by spawn rate), then `ZADD`s the run to `lb:time` / `lb:kills` / `lb:distance` and trims each board to its top 100.
- **`api/leaderboard.mjs`** — `GET` → one pipeline returns top 10 per board.
- **`api/_redis.mjs`** — ~15-line Upstash REST client over `fetch`. No npm dependencies.
- **`api/_check.mjs`** — runnable self-check for the sanity gate (`node api/_check.mjs`).
- **Overlay** — initials input (remembered in `localStorage`), 3-column boards panel, your own run highlighted gold. One submit per run; a first-ever run waits until initials are entered.

## Deploy requirements

- Site must be served by **Vercel** (static + `/api` in one project). On `file://` or GitHub Pages the API 404s — boards show "Leaderboards offline" and the game still plays.
- Add the **Upstash Redis** marketplace integration → it sets `KV_REST_API_URL` + `KV_REST_API_TOKEN` automatically.

## Notes

- **Anti-cheat: sanity caps only.** Client scores are forgeable; this stops casual direct POSTs, not a determined cheater. Deliberate for a portfolio easter egg. HMAC signing is the upgrade path if the board gets griefed.
- **Accuracy intentionally excluded** — shown as flavor on the card but never ranked (rewards timid single-shot play). Easy to add later as a kills tiebreaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)