### PR TITLE
Make music player and post-game modal mobile friendly, restyle debrief

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -302,25 +302,48 @@ html.flying #pageWorld { visibility: hidden; }
 /* game-over overlay */
 .gameover {
   position: fixed; inset: 0; z-index: 200;
-  display: grid; place-items: center; padding: 1.4rem;
+  display: grid; align-items: safe center; justify-items: center;
+  overflow-y: auto; -webkit-overflow-scrolling: touch;
+  padding:
+    calc(1.4rem + env(safe-area-inset-top))
+    calc(1.4rem + env(safe-area-inset-right))
+    calc(1.4rem + env(safe-area-inset-bottom))
+    calc(1.4rem + env(safe-area-inset-left));
   background: rgba(2,3,8,0.72); backdrop-filter: blur(6px);
   opacity: 0; transition: opacity .4s ease; pointer-events: auto;
 }
 .gameover[hidden] { display: none !important; }
 .gameover.in { opacity: 1; }
 .gameover__panel {
-  width: min(92vw, 460px); padding: 1.8rem 1.6rem; text-align: center;
-  border-radius: 20px;
-  background: linear-gradient(180deg, rgba(22,15,58,0.9), rgba(11,15,32,0.92));
+  position: relative;
+  width: min(92vw, 460px); margin: auto; padding: 1.9rem 1.6rem 1.7rem; text-align: center;
+  border-radius: 4px;
+  clip-path: polygon(18px 0, 100% 0, 100% calc(100% - 18px), calc(100% - 18px) 100%, 0 100%, 0 18px);
+  background:
+    linear-gradient(90deg, var(--gold), var(--rose) 55%, var(--cyan)) top / 100% 2px no-repeat,
+    linear-gradient(180deg, rgba(22,15,58,0.92), rgba(11,15,32,0.94));
   border: 1px solid var(--line); box-shadow: 0 30px 80px rgba(0,0,0,0.6);
   transform: translateY(12px) scale(.98); transition: transform .45s var(--ease);
 }
 .gameover.in .gameover__panel { transform: none; }
+.gameover__panel::before,
+.gameover__panel::after {
+  content: ""; position: absolute; width: 16px; height: 16px; pointer-events: none;
+}
+.gameover__panel::before { top: 9px; right: 9px; border-top: 2px solid rgba(127,214,232,.6); border-right: 2px solid rgba(127,214,232,.6); }
+.gameover__panel::after { bottom: 9px; left: 9px; border-bottom: 2px solid rgba(127,214,232,.6); border-left: 2px solid rgba(127,214,232,.6); }
+.gameover__head { margin-bottom: .3rem; }
+.gameover__tag {
+  display: block; font-family: var(--f-mono); font-size: .64rem; letter-spacing: .22em;
+  text-transform: uppercase; color: var(--cyan); margin-bottom: .5rem;
+}
 .gameover__title {
   font-family: var(--f-display); font-weight: 600;
-  font-size: clamp(2rem, 7vw, 3rem); color: var(--star); line-height: 1; margin-bottom: .3rem;
+  font-size: clamp(2rem, 7vw, 3rem); color: var(--star); line-height: 1;
+  text-shadow: 0 0 22px rgba(233,201,135,0.28);
 }
-.gameover__sub { color: var(--text-dim); font-style: italic; margin-bottom: 1.2rem; }
+.gameover__rule { display: block; width: 44px; height: 1px; background: var(--line); margin: .7rem auto 0; }
+.gameover__sub { color: var(--text-dim); font-style: italic; margin: .9rem 0 1.2rem; }
 .gameover__stats { display: grid; grid-template-columns: 1fr 1fr; gap: .7rem; margin-bottom: 1.1rem; }
 .gostat {
   padding: .7rem; border-radius: 12px;
@@ -360,9 +383,10 @@ html.flying #pageWorld { visibility: hidden; }
   font-size: .72rem; padding: .3rem .55rem; border-radius: 999px;
   background: rgba(233,201,135,0.12); border: 1px solid rgba(233,201,135,0.3); color: var(--gold);
 }
-.gameover__actions { display: flex; gap: .7rem; justify-content: center; }
+.gameover__actions { display: flex; gap: .7rem; justify-content: center; flex-wrap: wrap; }
 .gameover__btn {
-  font-family: var(--f-body); font-size: .86rem; padding: .6rem 1.2rem;
+  font-family: var(--f-mono); font-size: .76rem; letter-spacing: .1em; text-transform: uppercase;
+  padding: .65rem 1.3rem;
   border-radius: 999px; cursor: pointer; color: var(--text);
   background: transparent; border: 1px solid var(--line);
   transition: background .25s, border-color .25s, color .25s, box-shadow .25s;
@@ -370,6 +394,11 @@ html.flying #pageWorld { visibility: hidden; }
 .gameover__btn:hover { border-color: var(--cyan); color: var(--star); }
 .gameover__btn--go { background: var(--cyan); color: #062028; border-color: var(--cyan); font-weight: 600; }
 .gameover__btn--go:hover { background: #9be4f2; color: #062028; box-shadow: 0 0 18px rgba(127,214,232,0.5); }
+
+@media (max-width: 380px) {
+  .gameover__panel { padding: 1.6rem 1.1rem 1.4rem; }
+  .gameover__stats { grid-template-columns: 1fr; }
+}
 
 @media (prefers-reduced-motion: reduce) {
   .toast, .gameover, .gameover__panel { transition: none; }
@@ -1250,7 +1279,7 @@ body {
   display: flex; align-items: center; gap: .6rem;
   width: min(680px, calc(100% - 1.4rem));
   padding: .55rem .8rem;
-  margin-bottom: .7rem;
+  margin-bottom: max(.7rem, calc(env(safe-area-inset-bottom) + .3rem));
   background: rgba(11,15,32,0.72);
   border: 1px solid rgba(127,214,232,0.28);
   border-radius: 14px;
@@ -1317,5 +1346,17 @@ body {
 
 @media (max-width: 520px) {
   .player__time, .player__by { display: none; }
-  .player { gap: .45rem; }
+  .player { gap: .45rem; padding: .5rem .65rem; }
+  .player__btn { width: 2.35rem; height: 2.35rem; font-size: .85rem; }
+  .player__seek { height: 6px; min-width: 60px; }
+  .player__seek::-webkit-slider-thumb { width: 16px; height: 16px; }
+  .player__seek::-moz-range-thumb { width: 16px; height: 16px; }
+}
+
+/* touch devices can't hover to reveal the auto-hiding bar, so keep the
+   grabbable "lip" and its buttons comfortably tappable at all widths */
+@media (hover: none) {
+  .player__btn { width: 2.4rem; height: 2.4rem; font-size: .88rem; }
+  .player__seek::-webkit-slider-thumb { width: 17px; height: 17px; }
+  .player__seek::-moz-range-thumb { width: 17px; height: 17px; }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -81,12 +81,22 @@
       seekEl.addEventListener("change", commit);
     }
 
-    /* ---- auto-hide: collapse when the pointer leaves for a bit ---- */
+    /* ---- auto-hide: collapse when the pointer leaves for a bit ----
+       Only on devices that can actually hover — touch has no ambient
+       "pointer nearby" signal, so auto-collapsing there just makes the
+       bar vanish into an unreachable sliver. Touch users get it revealed
+       and left alone. */
     if (P) {
+      const canHover = window.matchMedia("(hover: hover) and (pointer: fine)").matches;
       let t;
-      const reveal = () => { P.classList.remove("is-collapsed"); clearTimeout(t); t = setTimeout(() => { if (!P.matches(":hover")) P.classList.add("is-collapsed"); }, 2800); };
+      const reveal = () => {
+        P.classList.remove("is-collapsed");
+        clearTimeout(t);
+        if (canHover) t = setTimeout(() => { if (!P.matches(":hover")) P.classList.add("is-collapsed"); }, 2800);
+      };
       P.addEventListener("pointerenter", reveal);
       P.addEventListener("pointermove", reveal);
+      P.addEventListener("touchstart", reveal, { passive: true });
       window.addEventListener("pointermove", (e) => { if (e.clientY > window.innerHeight - 70) reveal(); });
       reveal();
     }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   gtag('config', 'G-0GNGQLQQ8Q');
 </script>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 <title>Tyler Malone · Software Engineer</title>
 <meta name="description" content="Software Engineer specializing in full-stack development, DevOps, distributed systems, and agentic AI." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -99,7 +99,11 @@
 
 <div class="gameover" id="gameover" hidden aria-hidden="true">
   <div class="gameover__panel" role="dialog" aria-label="Game over">
-    <h2 class="gameover__title">You blew up</h2>
+    <div class="gameover__head">
+      <span class="gameover__tag">Flight Debrief</span>
+      <h2 class="gameover__title">You blew up</h2>
+      <span class="gameover__rule" aria-hidden="true"></span>
+    </div>
     <p class="gameover__sub" id="goSub"></p>
     <div class="gameover__stats" id="goStats"></div>
     <div class="gameover__name">


### PR DESCRIPTION
## Summary
- **Music player**: the auto-hide bar relied on `:hover`/pointer-proximity to reveal itself, which doesn't work on touch — it would collapse down to an unreachable ~6px sliver on mobile. It now skips the auto-collapse timer on devices that can't hover (`(hover: hover) and (pointer: fine)`), gets bigger tap targets for its buttons/seek thumb at small widths, and clears the iOS safe area so it doesn't sit under the home indicator.
- **Post-game modal ("Flight Debrief")**: the overlay had no `overflow`/scroll handling, so on short mobile viewports the bottom of the panel (leaderboards, medals, Fly again/Done buttons) got pushed off-screen with no way to reach it. Added scrollable overflow with scroll-trap-safe centering (`align-items: safe center`) so the whole panel is always reachable.
- Restyled the modal to match the site's existing HUD/console look (same fonts, colors, and glass-panel language as the Experience section) instead of a generic rounded card: chamfered panel corners with cyan corner-bracket accents, a gold→rose→cyan top accent bar (matching the site's scroll-progress bar), a mono "Flight Debrief" eyebrow tag above the title, and mono/uppercase action buttons (matching the site's existing pill CTA style) in place of the plain sentence-case buttons.

## Test plan
- [x] Verified in headless Chromium at multiple mobile viewports (320×568, 375×700, 390×844) via Playwright screenshots
- [x] Confirmed the post-game modal is scrollable end-to-end when content overflows the viewport (no scroll-trap) and centers normally when it fits
- [x] Confirmed the music player renders without horizontal overflow and buttons/seek bar are easily tappable at mobile widths
- [x] Confirmed desktop rendering (1280×900) still looks correct
- [ ] Manual test on a real iOS/Android device recommended before merge (safe-area-inset behavior can't be fully verified in a headless browser)

---
_Generated by [Claude Code](https://claude.ai/code/session_017NvirgD1r3xfin61fiTF77)_